### PR TITLE
feat(authz+monitor): pre-auth engine (★A) + live monitor core (★B) — Phase 1

### DIFF
--- a/.claude/skills/sirin-dev/SKILL.md
+++ b/.claude/skills/sirin-dev/SKILL.md
@@ -96,7 +96,7 @@ config/
 
 ```bash
 cargo check          # 0 errors required before commit
-cargo test --bin sirin    # currently 257 tests, all should pass
+cargo test --bin sirin    # currently 333 tests, all should pass
 cargo build --release     # ~5-7 min cold
 ./target/release/sirin.exe                       # launch GUI on port 7700
 SIRIN_RPC_PORT=7701 ./target/release/sirin.exe   # alt port if 7700 stuck
@@ -104,6 +104,27 @@ SIRIN_BROWSER_HEADLESS=false ./target/release/... # for Flutter / WebGL
 ```
 
 Avoid `cargo run` (debug build, slow startup, LLM calls may time out).
+
+### Preferred: `./scripts/dev-relaunch.sh`
+
+For any **smoke test or live-debug session**, use the helper script
+instead of the raw commands:
+
+```bash
+./scripts/dev-relaunch.sh                        # default 7700, headless
+SIRIN_RPC_PORT=7702 ./scripts/dev-relaunch.sh    # alt port
+SIRIN_BROWSER_HEADLESS=false ./scripts/dev-relaunch.sh  # for Flutter
+./scripts/dev-relaunch.sh --build-only           # just build, no launch
+```
+
+It chains: **kill old sirin → cargo build → print binary mtime + latest
+commit → fall-through to +1 port if zombie → exec**.
+
+Why it matters: bypassing this chain causes the "stale .exe" bug —
+running yesterday's binary against today's source.  This bit us when
+testing the eab8537 robustness actions (binary 10h older than commit
+returned `Unknown action` for everything).  Always use the script when
+the actions you're testing came from a recent commit.
 
 ## Common workflows
 
@@ -253,7 +274,16 @@ powershell -c "Get-Process sirin -ErrorAction SilentlyContinue | Stop-Process -F
 ### Can't rebuild while Sirin is running
 Windows holds the .exe open.  Kill Sirin (above) before
 `cargo build --release`, otherwise you get "access denied" silently
-keeping a stale binary.
+keeping a stale binary.  **Use `./scripts/dev-relaunch.sh`** to do
+this automatically (kill → build → relaunch in one shot).
+
+### Stale binary even when build "succeeded"
+Worse failure mode: you forget to kill, build appears to succeed (it
+re-uses .o files, only the final link fails on Windows file-lock,
+sometimes silently), and you launch the *previous* exe against new
+source.  Symptom: actions you just added in source return
+`Unknown browser_exec action: <name>` from MCP.  The script catches
+this by killing pre-build + verifying mtime post-build.
 
 ### `cargo run` vs `./target/release/sirin.exe`
 Always run release for any real work.  Debug build's LLM calls take

--- a/.sirin/.gitignore
+++ b/.sirin/.gitignore
@@ -1,0 +1,8 @@
+# Actual authz config and runtime state — never commit
+# The *.example file IS committed (it's the template other devs copy).
+
+authz.yaml
+audit.ndjson
+audit.ndjson.*
+trace-*.ndjson
+trace-*.ndjson.*

--- a/.sirin/authz.yaml.example
+++ b/.sirin/authz.yaml.example
@@ -1,0 +1,123 @@
+# Sirin Pre-Authorization config — EXAMPLE
+#
+# Copy to .sirin/authz.yaml (or ~/.sirin/authz.yaml for user-global) and customize.
+#
+# Precedence: deny > readonly_allow > allow > ask > default-deny
+# Repo-local overrides user-global; both merge with built-in Rust defaults.
+#
+# Full spec:            docs/DESIGN_AUTHZ.md
+# End-user usage doc:   docs/AUTHZ.md
+# ─────────────────────────────────────────────────────────────────────
+
+# mode: selective | strict | permissive | plan
+#   selective   — 預設:deny-by-default + explicit allow/deny/ask lists
+#   strict      — 所有 mutating action 都彈 ask(CI 不適用)
+#   permissive  — 只擋 deny,其他全 allow(本地 dev / 高信任場景)
+#   plan        — 禁所有 mutating(只允許 readonly,適合 AI 規劃階段)
+mode: selective
+
+# 純讀 action 無條件通過(yaml 只能擴充不能收斂內建 list)
+readonly_allow:
+  - ax_tree
+  - ax_find
+  - ax_value
+  - screenshot
+  - url
+  - title
+  - console
+  - network
+  - exists
+  - attr
+  - read
+
+# 各 MCP client 的 policy group
+# client_id 格式:<clientInfo.name>@<version>,如 claude-code@0.3.2
+# 支援 wildcard;沒 match 時 fallback "*"
+clients:
+  # Claude Code 跑在本地 repo,最高信任
+  "claude-code@*":
+    mode: permissive
+  # Claude Desktop 有可能跨 repo 使用
+  "claude-desktop@*":
+    mode: selective
+  # Cursor 同上
+  "cursor@*":
+    mode: selective
+  # Fallback
+  "*":
+    mode: selective
+
+# 允許規則
+# 欄位(任何組合):
+#   action            action 名(支援 * 前後綴,如 "ax_*")
+#   url_pattern       URL glob(* 一段,** 任意段)
+#   js_contains       只用於 eval:JS 字串需含此子字串
+#   name_substring    用於 ax_*:a11y name 需含此子字串
+#   name_regex        用於 ax_*:a11y name regex
+allow:
+  # ── 瀏覽:生產 / dev / 本地 ────────────────────────────────
+  - { action: goto, url_pattern: "https://redandan.github.io/**" }
+  - { action: goto, url_pattern: "https://agoramarket.purrtechllc.com/**" }
+  - { action: goto, url_pattern: "http://localhost:*/**" }
+  - { action: goto, url_pattern: "http://127.0.0.1:*/**" }
+
+  # ── a11y 互動(Flutter Web 主要通道) ───────────────────────
+  - { action: "ax_*", url_pattern: "https://redandan.github.io/**" }
+  - { action: "ax_*", url_pattern: "http://localhost:*/**" }
+
+  # ── 座標 fallback(CanvasKit 無 a11y 時) ────────────────────
+  - { action: click_point, url_pattern: "https://redandan.github.io/**" }
+  - { action: type,        url_pattern: "https://redandan.github.io/**" }
+
+  # ── 瀏覽器控制(不碰敏感內容) ────────────────────────────
+  - { action: set_viewport }
+  - { action: clear_browser_state }
+  - { action: wait_for_request }
+  - { action: wait_for_new_tab }
+  - { action: scroll, url_pattern: "**" }
+  - { action: key,    url_pattern: "**" }
+  - { action: wait,   url_pattern: "**" }
+
+# 拒絕規則(永遠最優先,即使 allow 重疊)
+deny:
+  # ── 敏感網域 ───────────────────────────────────────────────
+  - { url_pattern: "https://**paypal**/**" }
+  - { url_pattern: "https://**bank**/**" }
+  - { url_pattern: "https://*.stripe.com/**" }
+  - { url_pattern: "https://*.coinbase.com/**" }
+  - { url_pattern: "https://*.binance.com/**" }
+  - { url_pattern: "https://metamask.io/**" }
+
+  # ── 敏感 JavaScript(eval action) ─────────────────────────
+  - { action: eval, js_contains: "document.cookie" }
+  - { action: eval, js_contains: "window.ethereum" }
+  - { action: eval, js_contains: "navigator.credentials" }
+  - { action: eval, js_contains: "chrome.storage" }
+  - { action: eval, js_contains: "indexedDB.open" }
+
+  # ── 敏感輸入(ax_type / type) ────────────────────────────
+  - { action: "ax_type*",
+      not_name_matches: ["password", "密碼", "private key", "seed phrase", "助記詞", "ssn", "社會安全"] }
+
+# 需要彈 prompt 的 URL / action(一次性,人類一鍵決定)
+ask:
+  - { action: goto, url_pattern: "https://**.google.com/**" }
+  - { action: goto, url_pattern: "https://**github.com/settings/**" }
+  - { action: goto, url_pattern: "https://**github.com/*/settings/**" }
+
+# Learn mode:未知 pattern 第一次碰到時彈 ask + 給「Allow always」選項
+learn:
+  enabled: true
+  # 新學到的 allow 寫回 repo-local 還是 user-global
+  write_back_to: repo    # repo | user | memory_only
+  # 每個 MCP session 最多彈幾次 ask(防 AI 瘋狂 spam)
+  max_asks_per_session: 20
+
+# 稽核日誌
+audit:
+  # 路徑相對 .sirin/ 目錄
+  log_path: audit.ndjson
+  # 單檔超過此 size 自動 rotate
+  max_size_mb: 10
+  # 最多保留幾個 rotated file
+  max_backups: 5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,6 +1785,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2382,6 +2405,8 @@ dependencies = [
  "num-traits",
  "png",
  "tiff",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4526,11 +4551,13 @@ dependencies = [
  "eframe",
  "egui",
  "futures",
+ "globset",
  "grammers-client",
  "grammers-session",
  "headless_chrome",
  "image",
  "parking_lot",
+ "regex",
  "reqwest",
  "rhai",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,10 @@ tree-sitter-rust = "0.21"
 parking_lot = "0.12"
 rusqlite = { version = "0.31", features = ["bundled"] }
 headless_chrome = "1.0"
-image = { version = "0.25", default-features = false, features = ["png"] }
+image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 axum = { version = "0.8", features = ["ws"] }
+globset = "0.4"
+regex = "1.10"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/docs/DESIGN_AUTHZ.md
+++ b/docs/DESIGN_AUTHZ.md
@@ -1,0 +1,464 @@
+# Design: Pre-Authorization Engine
+
+**Status:** Proposed (design only, no implementation yet)
+**Target tier:** Tier 1 (safety / blast-radius)
+**Depends on:** none
+**Enables:** `DESIGN_MONITOR.md` (authz_ask prompts surface in GUI)
+
+---
+
+## 1. Why
+
+外部 AI(Claude Desktop / Claude Code / Cursor / 第三方 LLM)透過 MCP 呼叫 Sirin 的 `browser_exec`,目前**完全沒 gate**。LLM 幻覺出:
+
+```jsonc
+// 在使用者自己的 Chrome 裡執行
+{ "action": "ax_type", "backend_id": 42, "text": "<credit card number>" }
+{ "action": "goto", "target": "https://phishing.example/" }
+{ "action": "eval", "target": "navigator.credentials.get(...)" }
+```
+
+這些都會照做。需要一層像 Claude Code `settings.json` 的 **allow / deny / ask** 閘,但要 **URL-scoped** + **client-aware** + **learn-able**。
+
+## 2. Goals / Non-goals
+
+### Goals
+
+- 每個 `browser_exec` call 在執行前過一道 policy engine
+- 規則以 YAML 聲明,支援 URL glob、action name、JS 內容子字串、a11y label 子字串
+- 支援 `deny`(硬拒絕)、`allow`(白名單通過)、`ask`(彈 prompt 給人類)
+- 不同 MCP client 可以套不同 policy
+- 新規則 on-the-fly 學習(彈「Allow always」後寫回 yaml)
+- 所有決定寫 audit log
+
+### Non-goals
+
+- **不做身份認證**:連進 MCP 的都視為「已通過 transport 層認證」。authz 只管「能不能做這件事」,不管「你是誰」(client id 只用來差異化 policy,不做 verify)
+- **不取代 transport 安全**:Sirin 仍只聽 `127.0.0.1`,跨機存取要用 SSH tunnel / reverse proxy 自己顧
+- **不限制讀操作的輸出**:`ax_tree` 回完整 tree,不做 PII redaction(redact 屬於 observability / compliance 另一塊)
+
+## 3. Threat model
+
+| 情境 | 有無 authz 的差別 |
+|---|---|
+| LLM 亂下 `goto https://paypal.com` 後 `ax_type` | ❌ 無 authz:照做。✅ 有 authz:`paypal.com` 在 deny,整串拒絕 |
+| LLM 亂下 `eval "document.cookie"` 外洩 cookie | ❌ 無:cookie 出去。✅ 有:eval js_contains `document.cookie` 在 deny |
+| LLM 亂打 `ax_type` 到密碼欄 | ❌ 無:密碼寫進去。✅ 有:該 input label 含「password / 密碼」在 deny |
+| 正常測試 `goto redandan.github.io` → click → type | ✅ 有:allowlist 匹配 URL pattern,順暢跑 |
+| 測試新 URL 第一次碰到 | `mode=selective` 時彈 ask,用戶一鍵「Allow URL pattern」寫回 yaml |
+
+## 4. Configuration file
+
+### Location
+
+- **Repo-local**(優先):`<repo>/.sirin/authz.yaml` — 每個 repo 自己的規則,可 commit
+- **User-global**(fallback):`~/.sirin/authz.yaml` — 跨所有 repo 的 baseline
+- **Built-in default**:hard-coded strict defaults in Rust,用戶刪檔仍有基本防護
+
+Repo 覆寫 user,user 覆寫 default,**合併規則**:allow / deny / ask 三個 array 做 union;`mode` 取最後載入的值。
+
+### Schema
+
+```yaml
+# .sirin/authz.yaml
+
+# mode: selective | strict | permissive | plan
+#   selective   : deny-by-default + allow-list + ask-list(預設)
+#   strict      : 所有 mutating action 都 ask
+#   permissive  : 只擋 deny,其他全 allow(for dev / CI)
+#   plan        : 禁止所有 mutating action(只讓 AI 計畫,不讓它動)
+mode: selective
+
+# 完全零風險的 action,任何 client / URL 都直接過
+# 這組是 Sirin 內建的 hard-coded default,yaml 只能 *擴充* 不能收斂
+readonly_allow:
+  - ax_tree
+  - ax_find
+  - ax_value
+  - screenshot
+  - url
+  - title
+  - console
+  - network
+  - exists
+  - attr
+  - read
+
+# 每個 MCP client 的 policy group(client 名稱 match MCP initialize clientInfo.name)
+# 沒 match 時 fallback "*"
+clients:
+  "claude-code@*":
+    mode: permissive      # 開發場景,本地 Claude Code 完全信任
+  "claude-desktop@*":
+    mode: selective
+  "cursor@*":
+    mode: selective
+  "*":
+    mode: selective        # fallback
+
+# URL × action 允許規則(用於 mode=selective)
+# 欄位:
+#   action            action 名(支援 * wildcard)
+#   url_pattern       URL glob(支援 * 和 **)
+#   js_contains       (只用於 eval action)JS 字串需含此子字串
+#   name_substring    (用於 ax_* action)a11y name / value 需含此子字串
+#   name_regex        (用於 ax_* action)a11y name 正則(比 substring 強)
+#   not_name_matches  a11y name 不能含某些字(例如 password / 密碼)
+allow:
+  # 一般瀏覽
+  - { action: goto, url_pattern: "https://redandan.github.io/**" }
+  - { action: goto, url_pattern: "http://localhost:*/**" }
+  - { action: goto, url_pattern: "http://127.0.0.1:*/**" }
+
+  # a11y 互動(Flutter Web)
+  - { action: "ax_*", url_pattern: "https://redandan.github.io/**" }
+  - { action: "ax_*", url_pattern: "http://localhost:*/**" }
+
+  # 座標 click / type(兜底,CanvasKit 無 a11y 時)
+  - { action: click_point, url_pattern: "https://redandan.github.io/**" }
+  - { action: type,        url_pattern: "https://redandan.github.io/**" }
+
+  # 瀏覽器控制(不碰敏感內容)
+  - { action: set_viewport }
+  - { action: clear_browser_state }
+  - { action: wait_for_request }
+  - { action: wait_for_new_tab }
+  - { action: scroll, url_pattern: "**" }
+  - { action: key,    url_pattern: "**" }
+
+# 硬拒絕(永遠優先於 allow,即使規則重疊)
+deny:
+  # 敏感域名
+  - { url_pattern: "https://**paypal**/**" }
+  - { url_pattern: "https://**bank**/**" }
+  - { url_pattern: "https://*.stripe.com/**" }
+  - { url_pattern: "https://*.coinbase.com/**" }
+
+  # 敏感 JS
+  - { action: eval, js_contains: "document.cookie" }
+  - { action: eval, js_contains: "window.ethereum" }
+  - { action: eval, js_contains: "navigator.credentials" }
+  - { action: eval, js_contains: "chrome.storage" }
+
+  # 敏感輸入
+  - { action: "ax_type*",
+      not_name_matches: ["password", "密碼", "private key", "seed phrase", "助記詞", "ssn", "社會安全"] }
+  - { action: type,
+      url_pattern: "https://**login**/**",
+      js_contains: "password" }
+
+# 彈 GUI 問人類(一次性決定)
+ask:
+  - { action: goto, url_pattern: "https://**.google.com/**" }
+  - { action: goto, url_pattern: "https://**github.com/settings/**" }
+  - { action: goto, url_pattern: "https://**github.com/*/settings/**" }
+
+# Learn mode 設定
+learn:
+  # 開啟 learn mode:未知 pattern 第一次碰到時彈 ask,給「Allow always」選項
+  enabled: true
+  # 新學到的 allow 寫回哪:repo 或 user
+  write_back_to: repo    # repo | user | memory_only
+  # 最多彈幾次 ask 後就不再學(防 AI 瘋狂 spam)
+  max_asks_per_session: 20
+
+# 設定本身的驗證
+audit:
+  # 所有決定(allow / deny / ask 結果)寫入檔案(NDJSON,每行一個 event)
+  # 路徑相對 .sirin/ 目錄
+  log_path: audit.ndjson
+  # log rotation:超過 10 MB 自動 rotate(.1, .2, ...)
+  max_size_mb: 10
+  # 最多保留幾個 rotated file
+  max_backups: 5
+```
+
+### 內建 hard-coded default
+
+Rust side `authz::defaults()` 回傳:
+
+```yaml
+mode: selective
+readonly_allow: [ax_tree, ax_find, ax_value, screenshot, url, title, console, network, exists, attr, read]
+allow: []
+deny:
+  - { url_pattern: "file:///**" }                      # 本地 file:// 拒絕讀
+  - { url_pattern: "chrome://**" }                     # Chrome internal
+  - { url_pattern: "chrome-extension://**" }           # 擴充 internal
+  - { action: eval, js_contains: "document.cookie" }
+  - { action: eval, js_contains: "window.ethereum" }
+  - { action: eval, js_contains: "navigator.credentials" }
+  - { action: eval, js_contains: "indexedDB.open" }    # IDB 內容外洩路徑
+  - { action: "ax_type*",
+      not_name_matches: ["password", "密碼", "private key", "seed phrase", "助記詞"] }
+ask: []
+```
+
+刪 yaml 仍有這組 baseline。
+
+## 5. Decision engine
+
+### Algorithm
+
+```rust
+// src/authz/engine.rs (pseudo)
+pub fn decide(
+    client_id: &str,
+    action: &str,
+    args: &serde_json::Value,
+    current_url: &Option<String>,
+    config: &AuthzConfig,
+) -> Decision {
+    let policy = config.resolve_client_policy(client_id);
+
+    // 1. readonly_allow 直通
+    if config.readonly_allow.contains(action) {
+        return Decision::Allow("readonly");
+    }
+
+    // 2. deny 永遠最高優先
+    for rule in &config.deny {
+        if rule.matches(action, args, current_url) {
+            return Decision::Deny(rule.describe());
+        }
+    }
+
+    // 3. mode 簡單路徑
+    match policy.mode {
+        Mode::Permissive  => return Decision::Allow("permissive mode"),
+        Mode::Plan        => {
+            if is_mutating(action) {
+                return Decision::Deny("plan mode — mutating disabled");
+            }
+            return Decision::Allow("plan mode readonly");
+        }
+        Mode::Strict      => return Decision::Ask("strict mode — all mutating asks"),
+        Mode::Selective   => { /* continue */ }
+    }
+
+    // 4. allow 檢查
+    for rule in &config.allow {
+        if rule.matches(action, args, current_url) {
+            return Decision::Allow(rule.describe());
+        }
+    }
+
+    // 5. ask 檢查
+    for rule in &config.ask {
+        if rule.matches(action, args, current_url) {
+            return Decision::Ask(rule.describe());
+        }
+    }
+
+    // 6. Learn mode 路徑
+    if config.learn.enabled && !config.learn.exhausted() {
+        return Decision::AskWithLearn;
+    }
+
+    // 7. Default deny
+    Decision::Deny("no matching rule")
+}
+```
+
+### Pattern matching 細節
+
+- **URL glob**:用 `globset` crate(`*` 一段,`**` 任意段),不用自己寫 regex
+- **action name**:支援 `*` 前/後綴(`ax_*` 配 `ax_tree`, `ax_click` 等;`*` 配所有)
+- **js_contains / name_substring**:純 `String::contains`,case-insensitive
+- **name_regex**:用 `regex` crate,Rust-flavour
+- **not_name_matches**:array of substrings,**任何一個** match 就算違反(用於 deny)
+
+### Rule ordering
+
+- `deny` 比 `allow` 先過,即使是同 action/URL,deny 贏
+- `allow` 內部按 yaml 順序,第一個 match 就決定
+- `ask` 同樣按 yaml 順序
+
+## 6. MCP integration
+
+### 入口 gate
+
+`src/mcp_server.rs::call_browser_exec` 開頭加:
+
+```rust
+let decision = authz::decide(
+    &session.client_id,
+    &action,
+    &args,
+    &browser::current_url(),
+    &authz::config(),
+);
+
+match decision {
+    Decision::Allow(reason) => {
+        authz::audit::log_allow(&session, &action, &args, reason);
+    }
+    Decision::Deny(reason) => {
+        authz::audit::log_deny(&session, &action, &args, &reason);
+        return mcp_error(
+            format!("authz deny: {}", reason),
+            json!({ "action": action, "reason": reason, "hint": "add to .sirin/authz.yaml allow[]" })
+        );
+    }
+    Decision::Ask(reason) | Decision::AskWithLearn => {
+        // 推給 monitor GUI(見 DESIGN_MONITOR.md)
+        // 沒 GUI 時(headless mode)→ fallback to deny with reason
+        let resp = authz::ask_human(&session, &action, &args, reason, learn: matches!(decision, AskWithLearn)).await?;
+        match resp {
+            AskResponse::AllowOnce       => { authz::audit::log_allow_once(...); /* continue */ }
+            AskResponse::AllowAlways(rule) => { authz::learn::persist(rule)?; /* continue */ }
+            AskResponse::Deny            => {
+                authz::audit::log_deny(...);
+                return mcp_error("authz deny by human", ...);
+            }
+            AskResponse::Timeout         => {
+                authz::audit::log_timeout(...);
+                return mcp_error("authz ask timeout — treated as deny", ...);
+            }
+        }
+    }
+}
+```
+
+### Client id resolution
+
+MCP `initialize` 的 `clientInfo`:
+
+```json
+{ "clientInfo": { "name": "claude-code", "version": "0.3.2" } }
+```
+
+→ Sirin 組出 client_id `claude-code@0.3.2`。沒傳 clientInfo 則 `unknown@unknown`。
+
+每個 MCP session 的 client_id 存進 `SessionContext`,每個 call 都用它查 policy group。
+
+## 7. Audit log format
+
+NDJSON,每行一個 event,寫入 `.sirin/audit.ndjson`:
+
+```json
+{"ts":"2026-04-17T03:14:15.123Z","type":"allow","client":"claude-code@0.3.2","action":"ax_click","args":{"backend_id":42},"url":"https://redandan.github.io/#/wallet/withdraw","rule":"ax_* url=redandan.github.io/**"}
+{"ts":"...","type":"deny","client":"claude-desktop@1.2.0","action":"goto","args":{"target":"https://paypal.com/login"},"url":"about:blank","rule":"url=**paypal**"}
+{"ts":"...","type":"ask","client":"cursor@0.50","action":"goto","args":{"target":"https://google.com/oauth"},"url":"about:blank","decision":"allow_once","human_ts":"2026-04-17T03:14:22.456Z","wait_ms":7333}
+{"ts":"...","type":"learn","client":"claude-code@0.3.2","new_rule":{"action":"goto","url_pattern":"https://docs.flutter.dev/**"},"written_to":".sirin/authz.yaml"}
+```
+
+Rotation:超過 `max_size_mb` 時 rename 為 `audit.ndjson.1`,現有 `.1` → `.2`,超過 `max_backups` 的刪除。
+
+## 8. Learn mode details
+
+### 彈 prompt 的選項
+
+當 `AskWithLearn` 時,GUI 顯示:
+
+```
+┌─ Sirin AuthZ ──────────────────────────────────┐
+│ claude-desktop@1.2.0 requests:                 │
+│                                                │
+│   action: goto                                 │
+│   target: https://docs.flutter.dev/test       │
+│                                                │
+│ Not covered by any rule.                       │
+│                                                │
+│ [ Allow once                                 ] │
+│ [ Allow always for https://docs.flutter.dev/** ] │
+│ [ Allow always for any goto under this domain ] │
+│ [ Allow always for this action ]              │
+│ [ Deny once                                  ] │
+│ [ Deny + block this URL pattern              ] │
+└────────────────────────────────────────────────┘
+```
+
+### "Allow always" 寫回
+
+選擇後 append 到 target yaml(`.sirin/authz.yaml` 或 `~/.sirin/authz.yaml`,由 `learn.write_back_to` 決定)的 `allow:` 或 `deny:` list 末尾。寫入前:
+
+1. 讀 yaml → parse → insert → serialize → atomic rename(write-then-rename 確保不損壞)
+2. 重新載入 in-memory config
+3. audit log 寫一筆 `{type:"learn",...}`
+
+### 防 spam
+
+- `max_asks_per_session` 到上限後,新 ask 改成 auto-deny + warn,等 session restart 才 reset
+- 同一 rule pattern 1 秒內重複 ask 直接用上次決定
+
+## 9. Implementation plan
+
+### Files
+
+```
+src/authz/
+├── mod.rs          模組入口 + public API
+├── config.rs       yaml loader + schema structs
+├── engine.rs       decide() / rule matching
+├── audit.rs        NDJSON writer + rotation
+└── learn.rs        rule write-back + atomic rename
+
+.sirin/
+└── authz.yaml.example
+
+docs/
+└── AUTHZ.md        end-user facing(不是 design doc;用法範例 + troubleshooting)
+
+tests/
+├── authz_engine_test.rs      decide() 各 case
+├── authz_config_test.rs      yaml loader
+└── authz_learn_test.rs       write-back 不破壞檔案
+```
+
+### PRs
+
+| # | 內容 | 規模 |
+|---|---|---|
+| 1 | `src/authz/config.rs` + schema structs + loader | 1/2 day |
+| 2 | `src/authz/engine.rs` + matching + `decide()` + 單測 | 1 day |
+| 3 | `src/mcp_server.rs` 加 gate + client_id 解析 | 1/2 day |
+| 4 | `src/authz/audit.rs` + NDJSON writer | 1/2 day |
+| 5 | `ask_human()` fallback:沒 GUI 時 deny(獨立於 DESIGN_MONITOR) | 1/2 day |
+| 6 | `src/authz/learn.rs` + atomic write-back | 1/2 day |
+| 7 | `docs/AUTHZ.md` + `authz.yaml.example` + e2e smoke | 1/2 day |
+
+PR 1–5 可獨立上,無 GUI 時 `ask` 全部 fallback 成 `deny`,不卡 DESIGN_MONITOR。
+
+## 10. Test plan
+
+### Unit
+
+- 每個 `Decision::*` 分支都要有 case
+- Deny 比 allow 優先
+- readonly_allow 直通
+- client policy resolution(wildcard / exact / fallback)
+- glob pattern edge case(`**` 尾端 / query string / fragment)
+- name_regex / not_name_matches
+- Learn mode write-back 不破壞既有 yaml 順序 / comments(用 `serde_yaml` + 註解保留策略)
+- Audit log rotation 邊界
+
+### Integration
+
+- 起 Sirin + 送 MCP call,驗 audit log
+- 送 deny 會拿到 MCP error,`content` 帶 rule reason
+- 送 ask(用 mock GUI)會阻塞到決定回來
+- `max_asks_per_session` 到上限後 auto-deny
+
+### E2E(對 Agora Market)
+
+- `goto https://redandan.github.io/` + `ax_click` 登入按鈕,驗 log 是 `allow`
+- `goto https://paypal.com/` 驗 log 是 `deny`
+- `eval "document.cookie"` 驗 log 是 `deny`
+
+## 11. Open questions
+
+1. **yaml 順序對 learn 的影響**:`serde_yaml` 序列化會 reorder keys 嗎?要用 `yaml-rust2` 保留順序 + 註解嗎?
+2. **子 tab / iframe 的 URL 怎麼算**:`current_url` 指 top frame。iframe 內的 ax_click 要看 top 還是 iframe?建議用 top(攻擊面是 outer 網站)。
+3. **MCP session 結束時 audit flush**:`SessionStop` hook 保證 log buffer flush 到 disk
+4. **Learn mode 跟 version control**:repo `.sirin/authz.yaml` 被 learn 改了,是否該自動 `git add`?不該(侵入 VCS);只寫檔,由用戶決定
+5. **跨 Sirin instance 的 audit 合併**:多個 Sirin(多 port)同時跑時,各寫各的 `audit.ndjson`,path 按 port 區分:`audit-7700.ndjson`
+
+## 12. Backward compatibility
+
+- 舊 Sirin 沒 authz.yaml → 載入 built-in defaults,行為等同 `mode: selective` + 內建 deny list
+- 既有 MCP call 第一次試著做 `goto https://redandan.github.io` 會:
+  - 如果 yaml 有 allowlist → 直接過
+  - 如果 yaml 無 allowlist 且 `learn.enabled=true` → 彈 ask
+  - 如果 yaml 無 allowlist 且 `learn.enabled=false` → deny
+- 部署建議:第一次上線時 `learn.enabled=true` 跑一遍典型 workflow,讓它把 allowlist 自己學起來,然後手動 review `.sirin/authz.yaml` 確認規則合理,再 commit

--- a/docs/DESIGN_MONITOR.md
+++ b/docs/DESIGN_MONITOR.md
@@ -1,0 +1,426 @@
+# Design: Live GUI Monitor
+
+**Status:** Proposed (design only, no implementation yet)
+**Target tier:** Tier 1 (observability / debuggability)
+**Depends on:** `DESIGN_AUTHZ.md`(AuthZ ask prompts 在此 UI 浮現,但可獨立先上)
+**Enables:** trace viewer replay mode(歷史 ndjson replay 重用同個 UI)
+
+---
+
+## 1. Why
+
+現狀:外部 AI(Claude Desktop / Code / Cursor)用 MCP 呼叫 Sirin 時,**人類完全看不到**正在發生什麼:
+
+- 哪個 client 在跑
+- 跑了哪些 action / 結果是什麼
+- 當前 browser 頁面長怎樣
+- 有沒有 authz ask 等我回應
+- 出錯在哪一步
+
+要查只能事後翻 log。需要**實時 GUI**,滿足:
+
+- **看**:即時看 browser 螢幕 + action feed + console / network
+- **審**:authz ask 浮出來,一鍵 Allow/Deny
+- **控**:Pause / Step-through / Abort
+- **溯**:過去 N 分鐘的 trace 可以 replay
+
+## 2. Goals / Non-goals
+
+### Goals
+
+- 加入 Sirin 既有 egui 主 UI(`src/ui_egui/`)作為新的 view,**零新 GUI 框架**
+- Screenshot stream(取樣 500ms)+ action feed(即時)+ authz ask 浮層
+- Pause / Step / Abort 控制能中斷外部 AI 的操作流
+- Trace ndjson 寫檔,另一個 replay UI(同個元件,改 source)能看歷史
+- 可選 WebSocket server,讓遠端觀察者(瀏覽器 / 第二台機器)也能接
+
+### Non-goals
+
+- **不重寫既有 UI**:`ui_egui` 架構保留,Monitor 只是新 tab / view
+- **不做 Multi-user auth**:UI 本地 127.0.0.1 only,不做登入
+- **不取代 audit log**:UI 是**視覺化**audit log 的即時版,不是替代;log 仍是 source of truth
+- **Phase 1 不做 Systray**:系統列 icon 放 Phase 2,core feature 先出
+
+## 3. Architecture
+
+### 整合既有架構
+
+Sirin 現有(`docs/ARCHITECTURE.md`):
+
+```
+sirin.exe (單一進程)
+├── eframe + egui 0.31 (immediate mode UI)
+│   └── ui_egui/ {mod, sidebar, workspace, browser, log_view, settings, ...}
+├── ADK Runtime + Agents
+├── Memory / Events / MCP server (axum) / RPC
+└── Tokio async backend
+```
+
+Monitor 加入方式:
+
+```
+ui_egui/
+├── mod.rs                ← 加 MonitorView enum + routing
+├── sidebar.rs            ← 加 "Monitor" 選項
+└── monitor/              ← 【新】
+    ├── mod.rs            view 進入點
+    ├── action_feed.rs    動作 feed panel
+    ├── screenshot_pane.rs 即時截圖 panel
+    ├── control_bar.rs    Pause / Step / Abort + status
+    ├── authz_modal.rs    authz ask 浮層
+    ├── network_pane.rs   network 請求 list(折疊)
+    ├── console_pane.rs   console log(折疊)
+    └── state.rs          MonitorState(共享 state + event queue)
+```
+
+### Event flow
+
+```
+┌──────────────┐      mpsc::Sender<MonitorEvent>      ┌──────────────┐
+│   mcp_server │─────────────────────────────────────▶│              │
+│  / browser / │                                      │ MonitorState │
+│  authz / cdp │                                      │   (Arc<RwLock>)
+└──────────────┘                                      │              │
+                                                      └──────┬───────┘
+                                                             │ (egui polls every frame)
+                                                             ▼
+                                                      ┌──────────────┐
+                                                      │  ui_egui     │
+                                                      │  /monitor/*  │
+                                                      └──────────────┘
+                                                             │
+                                                             │ user interaction
+                                                             ▼
+                                                      ┌──────────────┐
+                                                      │ control send │
+                                                      │  ControlCmd  │
+                                                      └──────┬───────┘
+                                                             │ mpsc
+                                                             ▼
+                                                      ┌──────────────┐
+                                                      │ authz / exec │
+                                                      │  awaits cmd  │
+                                                      └──────────────┘
+```
+
+### Screenshot pump
+
+獨立 tokio task,**只在有 MonitorView active 時才跑**:
+
+```rust
+async fn screenshot_pump(
+    state: Arc<RwLock<MonitorState>>,
+    browser: Arc<BrowserHandle>,
+) {
+    let mut interval = tokio::time::interval(Duration::from_millis(500));
+    loop {
+        interval.tick().await;
+        if !state.read().await.view_active { continue; }
+        if state.read().await.paused_stream { continue; }
+        match browser.screenshot_jpeg(80).await {
+            Ok(bytes) => state.write().await.push_screenshot(bytes),
+            Err(e)    => state.write().await.push_error(e),
+        }
+    }
+}
+```
+
+策略:
+- JPEG quality 80,壓低傳輸成本(egui texture upload)
+- `view_active` + `paused_stream` 兩層 gate,不看就不花 CPU
+- 失敗一次不重啟(log 就好),避免雪崩
+
+### Control state
+
+```rust
+pub struct ControlState {
+    pub paused:   AtomicBool,    // 暫停所有 action,等 resume
+    pub step:     AtomicBool,    // 跑下一個 action 後自動 paused=true
+    pub aborted:  AtomicBool,    // 立即拒絕所有後續 action
+}
+
+impl ControlState {
+    /// 每個 action 進入時 gate 一下。paused 時輪詢等,aborted 直接 error。
+    pub async fn gate(&self) -> Result<(), AbortError> {
+        if self.aborted.load(Relaxed) { return Err(AbortError); }
+        while self.paused.load(Relaxed) {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            if self.aborted.load(Relaxed) { return Err(AbortError); }
+        }
+        if self.step.swap(false, Relaxed) {
+            self.paused.store(true, Relaxed);
+        }
+        Ok(())
+    }
+}
+```
+
+MCP server 的 `call_browser_exec` 在 authz 之後、executor 之前插入 `control.gate().await`。
+
+## 4. UI spec
+
+### Main layout(egui)
+
+```
+┌─ Sirin ────────────────────────────────────────────┐
+│ [Workspace] [Browser] [Monitor●] [Settings] [Logs] │ ← sidebar,● 表示 active session 中
+├─ Monitor ──────────────────────────────────────────┤
+│                                                    │
+│ Status: 🟢 Active  Port 7703  │ clients:           │
+│                                │ • claude-desktop  │
+│                                │ • claude-code     │
+│                                                    │
+│ ┌─────────────────────────┐ ┌─ CONTROL ──────────┐ │
+│ │                         │ │ ▶ Running          │ │
+│ │  [screenshot ~640x400]  │ │ [Pause] [Step]     │ │
+│ │                         │ │ [Abort]            │ │
+│ │  URL: /wallet/withdraw  │ │                    │ │
+│ └─────────────────────────┘ └────────────────────┘ │
+│                                                    │
+│ ┌─ ACTION FEED ───────────────────────────────────┐│
+│ │ 12:34:10.123  claude-desktop                    ││
+│ │   ax_find role=button, name=確認提款             ││
+│ │   ↳ {backend_id:42, name:"確認提款"}            ││ ← expandable row
+│ │ 12:34:10.456  claude-desktop                    ││
+│ │   ax_click 42   ✓ (38ms)                        ││
+│ │ ─────────────────────────────────────────────── ││
+│ │ ⚠ 12:34:11.789  claude-desktop  AUTHZ ASK       ││
+│ │   goto https://docs.flutter.dev/test            ││
+│ │   not covered by any rule                       ││
+│ │   [Allow once] [Allow URL*] [Allow action*]     ││
+│ │   [Deny] [Deny + block URL]                     ││ ← 點擊送 AuthzDecision
+│ │ ─────────────────────────────────────────────── ││
+│ │ 12:34:13.002  claude-code                       ││
+│ │   ax_tree → 55 nodes                            ││
+│ │ ...                                             ││
+│ └─────────────────────────────────────────────────┘│
+│                                                    │
+│ [Console 0 err] [Network 5 req] [A11y 55 nodes]   │ ← 折疊 panel
+│                                                    │
+│ [Export trace.ndjson] [Clear] [Replay mode...]    │
+└────────────────────────────────────────────────────┘
+```
+
+### Action feed row
+
+每行:
+
+- **時間戳**(`HH:MM:SS.mmm`)
+- **client id**(彩色 chip 區分)
+- **action + 關鍵 args**(一行摘要)
+- **結果 icon**(✓ 綠,✗ 紅,⚠ 黃 ask,⏸ 灰 paused)
+- **耗時**(action_done 回來才填)
+- **展開區**(點擊):完整 args json、完整 result json、關聯 screenshot(前後對比)
+
+AuthZ ask row 特殊:按鈕內嵌在 row 裡,點擊送 `AuthzDecision` 給等待的 task。超時計時器(預設 30s)顯示在 row 尾。
+
+### Screenshot pane
+
+- 頂部顯示當前 URL(點擊 → 複製到 clipboard)
+- 圖片 fit-height-aspect-preserve
+- 底部 toolbar:
+  - `⏸ Pause stream` / `▶ Resume stream`(不影響 action gate)
+  - `💾 Save PNG`(存當前 frame)
+  - `🔍 Open full` (egui window)
+- Stream 斷線時顯示「reconnecting…」並持續重試
+
+### Control bar
+
+- Status dot:🟢 active / 🟡 paused / 🔴 aborted / ⚪ idle (no recent activity)
+- Pause:set `paused=true`,in-flight action 仍會做完,下一個開始前卡住
+- Step:先 set `paused=false` 讓當前通過,下一個 action 自動 pause(UI icon 變「⏭ 1 queued」)
+- Abort:set `aborted=true`,popup 確認「This will reject all further actions. Continue?」
+- 視覺:pause 時整個 UI 淡黃底色,abort 時紅底色,一眼看出來
+
+### AuthZ modal vs inline
+
+兩種呈現可切換(settings):
+
+- **Inline**(預設):ask 直接插進 action feed,feed 繼續滾
+- **Modal**:浮出 window 擋住 UI,強制先回應。適合獨立 display
+
+## 5. WebSocket server(optional)
+
+給遠端觀察:
+
+```
+listen on 127.0.0.1:<SIRIN_WS_PORT || 7703 + 1>
+path: /monitor/ws
+protocol: JSON text frames (not binary)
+```
+
+### 訊息 schema
+
+```typescript
+// Server → Client
+type ServerEvent =
+  | { type:"hello", ts, sirin_version, clients:string[] }
+  | { type:"action_start", id, ts, client, action, args }
+  | { type:"action_done",  id, ts, result, duration_ms }
+  | { type:"action_error", id, ts, error }
+  | { type:"authz_ask",    request_id, client, action, args, url, timeout_ms, learn:bool }
+  | { type:"authz_resolved", request_id, decision }
+  | { type:"screenshot",   ts, jpeg_base64 }                        // 500ms tick
+  | { type:"url_change",   ts, url }
+  | { type:"console",      ts, level, text }
+  | { type:"network",      ts, url, method, status, size, req_body_preview, res_body_preview }
+  | { type:"state",        paused, step, aborted, view_active }
+  | { type:"goodbye" }
+
+// Client → Server
+type ClientCommand =
+  | { type:"authz_response", request_id, decision:"allow_once"|"allow_always_url"|"allow_always_action"|"deny"|"deny_block" }
+  | { type:"pause" }
+  | { type:"resume" }
+  | { type:"step" }
+  | { type:"abort" }
+  | { type:"subscribe", channels:("screenshot"|"action"|"network"|"console")[] }
+```
+
+### 安全
+
+- **只綁 127.0.0.1**,外網存取要自己 SSH tunnel
+- 可選 token:啟動時生成 random token,WS URL 要 `?token=<>`,錯 → 401 close
+- Origin check:只接 `http://localhost:*` / `http://127.0.0.1:*`
+
+### 關係
+
+egui 主 UI 是 first-class(共享 process memory,免序列化)。WS 是**額外**的觀察 channel,schema 跟 egui 看的是同一份 `MonitorState` 轉 JSON,不分兩套邏輯。
+
+## 6. Trace ndjson
+
+### 寫檔
+
+每個 Sirin session 開啟時建立 `<repo>/.sirin/trace-<ISO8601>.ndjson`,與 audit log 分開(audit 是 authz 決定,trace 是**全部**action 時序)。
+
+Event 同 WS server 的 `ServerEvent` schema,序列化一樣。
+
+### Rotation
+
+- 新 session 新檔
+- 單檔超過 100 MB auto-rotate(.1, .2),保留最多 20 個
+
+### Replay mode
+
+egui 新的 `Replay` view:
+
+- 選擇 ndjson 檔 / 拖拉進來
+- UI 用**同一組 component** render,但 event source 從 mpsc channel 變 file iterator
+- 時間軸:拉 scrubber 到任何時點,state 重建到那個 moment
+- 速度:0.5x / 1x / 2x / 5x / instant seek
+- Filter:只看某個 client、某種 event type
+
+這直接實現 ROADMAP Tier 1 T2(Trace viewer),不用寫第二套 UI。
+
+## 7. Implementation plan
+
+### Files
+
+```
+src/
+├── monitor/
+│   ├── mod.rs              模組 API:init()/emit_*(event) helpers
+│   ├── state.rs            MonitorState(Arc<RwLock<>>) + event queue
+│   ├── events.rs           ServerEvent / ClientCommand enum
+│   ├── screenshot_pump.rs  tokio task
+│   ├── trace_writer.rs     NDJSON writer + rotation
+│   └── ws.rs               【optional】axum WebSocket handler
+│
+├── ui_egui/
+│   ├── mod.rs              加 MonitorView 路由
+│   ├── sidebar.rs          加 "Monitor" 入口
+│   └── monitor/
+│       ├── mod.rs          view::show(ui, state)
+│       ├── action_feed.rs
+│       ├── screenshot_pane.rs
+│       ├── control_bar.rs
+│       ├── authz_modal.rs
+│       ├── network_pane.rs
+│       └── console_pane.rs
+│
+└── mcp_server.rs           加 control.gate() + emit events
+```
+
+### PRs
+
+| # | 內容 | 規模 | 相依 |
+|---|---|---|---|
+| M1 | `src/monitor/state.rs` + `events.rs` + emit helpers | 1/2 day | - |
+| M2 | `mcp_server.rs` hook:每個 action 前後 emit event | 1/2 day | M1 |
+| M3 | `src/monitor/screenshot_pump.rs` + browser JPEG API | 1 day | M1 |
+| M4 | `src/monitor/trace_writer.rs` + rotation | 1/2 day | M1 |
+| M5 | `src/ui_egui/monitor/` — action_feed + screenshot_pane 雛形 | 1-2 days | M1, M3 |
+| M6 | `src/monitor/control.rs` + Pause/Step/Abort + UI control_bar | 1 day | M5 |
+| M7 | `src/ui_egui/monitor/authz_modal.rs` + 整合 `DESIGN_AUTHZ` ask | 1/2 day | M5, AUTHZ PR 5 |
+| M8 | `src/monitor/ws.rs`(WS server)+ auth token | 1 day | M1, M2 |
+| M9 | Replay mode(load ndjson,重用 monitor UI) | 1-2 days | M4, M5 |
+
+**Phase 1(核心 UI,無 WS,無 replay)**:M1+M2+M3+M5+M6 ≈ 4 days
+**Phase 2(+ authz 整合 + WS + replay)**:M7+M8+M9 ≈ 2.5 days
+**Total**:~7 days full time
+
+### Dependencies (Cargo.toml)
+
+全部現有 deps 夠用:
+
+- `eframe 0.31` / `egui 0.31` ✓ 已有
+- `axum 0.8` with `ws` feature ✓ 已有
+- `tokio 1.37` ✓ 已有
+- `serde / serde_json` ✓ 已有
+- `image 0.25` ← 新增,egui JPEG decode(或用 `egui_extras`)
+
+## 8. Performance budget
+
+- Screenshot pump:500ms interval,JPEG 80% 640×400 典型 ~50 KB → 100 KB/s peak
+- Action feed:每個 event ~500 bytes,100 events/s 也才 50 KB/s
+- UI frame:egui repaint 60 FPS,只 repaint 變更區域,當無新 event 時背壓 10 FPS
+- 記憶體:MonitorState 保留最近 1000 個 action + 50 個 screenshot frame(~5 MB),超過淘汰
+
+目標:Monitor active 時 Sirin 整體 CPU <5%、額外 RAM <50 MB。
+
+## 9. Test plan
+
+### Unit
+
+- `MonitorState` event queue 滿時淘汰邏輯
+- `trace_writer` rotation 邊界
+- `control.gate()` 對 pause / step / abort 的各組合
+
+### Integration
+
+- 起 Sirin,從 egui 進 Monitor view,發 MCP call,驗 feed 有 row
+- Pause 後發 action,驗 action 卡住;Resume 後完成
+- Abort 後發 action,MCP 直接 error
+- WS client 接 ws://127.0.0.1:7704/monitor/ws,驗 event 收到
+
+### E2E
+
+- AgoraMarket phase3-atomic.sh 跑一遍,Monitor 從頭看到尾,screenshot 同步 + 所有 action feed 有記錄 + trace ndjson 完整
+
+## 10. Open questions
+
+1. **Sirin 已跑 no-UI 模式(CLI / headless)時 Monitor 如何?** → 建議自動停用 GUI 部分,保留 trace ndjson + WS server(讓遠端 UI 接)。
+2. **多 Sirin instance 時 WS 埠怎麼分?** → `SIRIN_RPC_PORT=7703` 時 WS 用 `7703 + 1000 = 8703`,避開常用 port
+3. **Screenshot 對 CanvasKit 負擔**:CDP `Page.captureScreenshot` 每 500ms 對 Flutter GPU pipeline 有無明顯影響?→ 需 benchmark,必要時降到 1s。
+4. **Trace ndjson 隱私**:包含所有 URL / ax_tree / 可能包含 console 機敏文字。→ `.sirin/` 要 gitignore;可選 `redact_patterns` 在寫檔前做
+5. **egui 能 render JPEG base64 嗎?** → 需 `egui_extras::install_image_loaders` + `image` crate decode,egui 0.31 有。
+
+## 11. 跟 DESIGN_AUTHZ 的合體
+
+兩個設計獨立,但有整合點:
+
+- **AUTHZ PR 5**(`ask_human()` 實作):有 Monitor active 時推送 `authz_ask` event,等 `AuthzDecision` 回來;無 Monitor 時立即 fallback 成 deny
+- **Monitor M7**(authz_modal):訂閱 `authz_ask` event,渲染 ask row / modal,收集用戶點擊回送 decision
+
+沒 Monitor 也能用 AuthZ(fallback deny),沒 AuthZ 也能用 Monitor(只有 action feed 沒 ask),兩者是 additive。
+
+## 12. 長遠 vision
+
+Phase 3(不在本 PR):
+
+- **Systray**:`tray-icon` crate,icon 顏色反映 state,右鍵菜單 pause all / abort all / open monitor
+- **Multi-session view**:一個 Sirin instance 同時服務多個 MCP client,UI 加 tab 切換看每個 client 各自的 feed
+- **Bookmark 時點**:看到有趣 event 按 B 標記,之後 replay 時快速跳
+- **Export HTML report**:從 trace ndjson 生成靜態 HTML,分享給同事看 bug 復現
+
+這些都是 Phase 1 完成後的 nice-to-have,不擋核心交付。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -511,3 +511,60 @@ T-10 (系統托盤) — 獨立
 | 中期 | T-08 Follow-up 改進 | 改善現有自主循環品質 |
 | 長期 | T-09 Persona 更新 | 真正的自我優化閉環 |
 | 長期 | T-10 系統托盤 | UX 完善 |
+
+---
+
+# 附錄:MCP / Testing Roadmap(2026-04-17 起)
+
+Sirin 除了原本的 self-optimizing agent 方向,也變成**外部 AI 透過 MCP 驅動瀏覽器**的基礎設施(Claude Code / Desktop / Cursor 都在用)。這條線有獨立的演化方向 —— 重點不是「Sirin 更聰明」,是「Sirin 更安全、更穩、更可觀察」。
+
+## Tier 1 — 止血(痛點立即感受)
+
+| # | 項目 | 規模 | 文件 |
+|---|---|---|---|
+| **T-M01** | Windows zombie port wrapper(issue #14 自修復) | 1/2 day | — |
+| **T-M02 ★A** | **Pre-Authorization engine**(外部 AI gate,防幻覺 `eval document.cookie` 等) | 3–5 day | `docs/DESIGN_AUTHZ.md` |
+| **T-M03 ★B** | **Live GUI Monitor**(egui 內的即時 screenshot / action feed / authz ask + Pause/Step/Abort) | 5–7 day | `docs/DESIGN_MONITOR.md` |
+| **T-M04** | Trace NDJSON + Replay mode(★B UI 重用) | 1–2 day(在 ★B 之上) | `DESIGN_MONITOR.md` §6 |
+
+## Tier 2 — 擴能
+
+| # | 項目 | 規模 |
+|---|---|---|
+| T-M05 | `page_state` 聚合查詢(url+ax+screenshot+console+net 一次回) | 1 day |
+| T-M06 | `ax_find` 加 regex + `not_name_matches` | 1/2 day |
+| T-M07 | `ax_diff(before, after)` + `wait_for_ax_change` | 1 day |
+| T-M08 | Fixture 管理(`with_fixture { setup, cleanup }`) | 1 day |
+| T-M09 | Parallel test execution(多 Chrome profile 同時跑) | 2–3 day |
+
+## Tier 3 — 生態
+
+| # | 項目 | 規模 |
+|---|---|---|
+| T-M10 | Playwright protocol bridge(接 Playwright trace viewer / codegen) | 1–2 weeks |
+| T-M11 | VSCode extension(即時 screenshot + ax tree panel) | 1 week |
+| T-M12 | CLI / REPL mode(`sirin exec goto …` 免 curl-heredoc) | 2–3 day |
+| T-M13 | Systray helper(tray-icon,★B 第二階段) | 2 day |
+
+## Tier 4 — 社群
+
+| # | 項目 | 規模 |
+|---|---|---|
+| T-M14 | `examples/agora-market.md`(固化已驗 a11y 節點 cheatsheet) | 1/2 day |
+| T-M15 | `cargo build` emit `schema.json`(外部 LLM tool-use 可消費) | 1/2 day |
+| T-M16 | Benchmark harness(`cargo bench` 跑典型 action 組合) | 1 day |
+
+## 優先序建議
+
+```
+立即 │ T-M01 zombie port → T-M02 AuthZ → T-M03 Monitor
+短期 │ T-M04 trace replay → T-M05 page_state → T-M14 agora cheatsheet
+中期 │ T-M07/M08 ax_diff / fixture → T-M12 CLI → T-M13 systray
+長期 │ T-M09 parallel → T-M10 Playwright bridge → T-M11 VSCode ext
+```
+
+## 跟原 T-01..T-15 Agent 方向的關係
+
+- **獨立**:MCP/Testing 方向不動 agent core(memory / persona / follow-up)
+- **共用**:同個 `sirin.exe` 進程、同個 egui UI、同個 tokio runtime
+- **互補**:Monitor 的 trace ndjson 之後也能給 agent 做 self-optimize 的 training data(T-07 品質評分的一個新 input source)

--- a/scripts/dev-relaunch.sh
+++ b/scripts/dev-relaunch.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# scripts/dev-relaunch.sh
+#
+# Safe rebuild + relaunch loop for Sirin dev.  Solves three Windows pitfalls:
+#
+#   1. Stale .exe — Windows holds sirin.exe open while a process is running,
+#      so `cargo build --release` fails (sometimes silently) and you end up
+#      running yesterday's binary against today's source.
+#   2. Port zombie (issue #14) — old TCP listener may still be bound after
+#      the process exits.  We auto-fall-through to a +1 port when that happens.
+#   3. Forgetting to rebuild before smoke test — bit us today (eab8537 commit
+#      had robustness actions but the .exe was 10h older → "Unknown action").
+#
+# Usage:
+#
+#   ./scripts/dev-relaunch.sh                       # default port 7700, headless
+#   SIRIN_RPC_PORT=7702 ./scripts/dev-relaunch.sh   # custom port
+#   SIRIN_BROWSER_HEADLESS=false ./scripts/dev-relaunch.sh   # for Flutter
+#   ./scripts/dev-relaunch.sh --build-only          # build, do not launch
+#
+# Exits non-zero if cargo build fails (does NOT launch a stale binary).
+
+set -e
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+BUILD_ONLY=0
+[[ "$1" == "--build-only" ]] && { BUILD_ONLY=1; shift; }
+
+PORT="${SIRIN_RPC_PORT:-7700}"
+HEADLESS="${SIRIN_BROWSER_HEADLESS:-true}"
+
+# ── 1. Kill any running sirin (Windows .exe lock + port reuse) ─────────────
+echo "[1/4] Killing any running sirin.exe..."
+if command -v powershell >/dev/null 2>&1; then
+    powershell -c "Get-Process sirin -ErrorAction SilentlyContinue | Stop-Process -Force" 2>/dev/null || true
+elif command -v pkill >/dev/null 2>&1; then
+    pkill -f sirin || true
+fi
+sleep 1
+
+# ── 2. Build release ────────────────────────────────────────────────────────
+echo "[2/4] cargo build --release..."
+cargo build --release
+
+# ── 3. Sanity: binary mtime vs latest commit ────────────────────────────────
+echo "[3/4] Binary check:"
+if [[ -f target/release/sirin.exe ]]; then
+    BIN=target/release/sirin.exe
+elif [[ -f target/release/sirin ]]; then
+    BIN=target/release/sirin
+else
+    echo "  ERROR: no release binary found" >&2
+    exit 1
+fi
+echo "  binary:        $BIN ($(stat -c %y "$BIN" 2>/dev/null || stat -f %Sm "$BIN"))"
+echo "  latest commit: $(git log -1 --format='%ai %h %s')"
+
+[[ $BUILD_ONLY -eq 1 ]] && { echo "[4/4] --build-only set, exiting."; exit 0; }
+
+# ── 4. Probe port; fall through to +1 if zombie-occupied ────────────────────
+PROBED=""
+for offset in 0 1 2 3; do
+    TRY=$((PORT + offset))
+    if command -v powershell >/dev/null 2>&1; then
+        # Use Test-NetConnection-equivalent check.  Get-NetTCPConnection
+        # returns nothing when free → echoed "True" by `-eq $null`.
+        FREE=$(powershell -NoProfile -Command \
+            "if ((Get-NetTCPConnection -LocalPort $TRY -State Listen -ErrorAction SilentlyContinue) -eq \$null) { 'free' } else { 'busy' }" 2>/dev/null | tr -d '\r\n ')
+        if [[ "$FREE" == "free" ]]; then
+            PROBED=$TRY
+            break
+        fi
+    else
+        # POSIX: just trust the env var
+        PROBED=$TRY
+        break
+    fi
+done
+if [[ -z "$PROBED" ]]; then
+    echo "  ERROR: ports $PORT..$((PORT+3)) all occupied" >&2
+    exit 1
+fi
+[[ "$PROBED" != "$PORT" ]] && echo "  WARN: port $PORT busy, falling through to $PROBED"
+
+echo "[4/4] Launching: SIRIN_RPC_PORT=$PROBED SIRIN_BROWSER_HEADLESS=$HEADLESS $BIN $@"
+echo
+SIRIN_RPC_PORT="$PROBED" \
+    SIRIN_BROWSER_HEADLESS="$HEADLESS" \
+    exec "$BIN" "$@"

--- a/src/adk/tool/builtins.rs
+++ b/src/adk/tool/builtins.rs
@@ -883,9 +883,8 @@ pub(super) fn build_full_registry() -> ToolRegistry {
                     // ── Multi-tab / popup ────────────────────────
                     "wait_new_tab" => {
                         let timeout = input.get("timeout").and_then(Value::as_u64).unwrap_or(10000);
-                        // baseline = current tab count
-                        let baseline = browser::list_tabs().map(|v| v.len()).unwrap_or(1);
-                        let idx = browser::wait_for_new_tab(baseline, timeout)?;
+                        // baseline=None → fn measures from same source as its loop
+                        let idx = browser::wait_for_new_tab(None, timeout)?;
                         Ok(json!({ "status": "new tab opened", "active_tab": idx }))
                     }
 

--- a/src/authz/audit.rs
+++ b/src/authz/audit.rs
@@ -1,0 +1,260 @@
+/// NDJSON audit log writer.
+///
+/// Each authorization decision is written as a single JSON line to a file.
+/// Append-only; no rotation in this PR (rotation is a follow-up task).
+///
+/// Event format (§7 of DESIGN_AUTHZ.md):
+///
+/// ```json
+/// {"ts":"2026-04-17T03:14:15.123Z","type":"allow","client":"claude-code@0.3.2",
+///  "action":"ax_click","args":{"backend_id":42},
+///  "url":"https://redandan.github.io/#/wallet","rule":"readonly_allow"}
+/// ```
+
+use chrono::Utc;
+use serde_json::{json, Value as JsonValue};
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+
+// ─── Public helpers ───────────────────────────────────────────────────────────
+
+/// Write a single NDJSON event to the audit log at `log_path`.
+///
+/// Creates the file (and parent dirs) if it doesn't exist.
+/// Silently swallows write errors (audit failure must not block the call).
+pub fn append_event(log_path: &str, event: &JsonValue) {
+    let path = Path::new(log_path);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    let mut line = serde_json::to_string(event).unwrap_or_else(|_| "{}".to_string());
+    line.push('\n');
+
+    let file = OpenOptions::new().create(true).append(true).open(path);
+    if let Ok(mut f) = file {
+        let _ = f.write_all(line.as_bytes());
+    }
+}
+
+/// Log an `allow` decision.
+pub fn log_allow(
+    log_path: &str,
+    client: &str,
+    action: &str,
+    args: &JsonValue,
+    url: &Option<String>,
+    rule: &str,
+) {
+    let ev = json!({
+        "ts":     Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        "type":   "allow",
+        "client": client,
+        "action": action,
+        "args":   args,
+        "url":    url.as_deref().unwrap_or(""),
+        "rule":   rule,
+    });
+    append_event(log_path, &ev);
+}
+
+/// Log a `deny` decision.
+pub fn log_deny(
+    log_path: &str,
+    client: &str,
+    action: &str,
+    args: &JsonValue,
+    url: &Option<String>,
+    rule: &str,
+) {
+    let ev = json!({
+        "ts":     Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        "type":   "deny",
+        "client": client,
+        "action": action,
+        "args":   args,
+        "url":    url.as_deref().unwrap_or(""),
+        "rule":   rule,
+    });
+    append_event(log_path, &ev);
+}
+
+/// Log an `ask` event (before the human responds).
+pub fn log_ask(
+    log_path: &str,
+    client: &str,
+    action: &str,
+    args: &JsonValue,
+    url: &Option<String>,
+    rule: &str,
+) {
+    let ev = json!({
+        "ts":     Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        "type":   "ask",
+        "client": client,
+        "action": action,
+        "args":   args,
+        "url":    url.as_deref().unwrap_or(""),
+        "rule":   rule,
+    });
+    append_event(log_path, &ev);
+}
+
+/// Log a `learn` event when a new rule is persisted.
+pub fn log_learn(
+    log_path: &str,
+    client: &str,
+    new_rule: &JsonValue,
+    written_to: &str,
+) {
+    let ev = json!({
+        "ts":         Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        "type":       "learn",
+        "client":     client,
+        "new_rule":   new_rule,
+        "written_to": written_to,
+    });
+    append_event(log_path, &ev);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod audit_test {
+    use super::*;
+    use serde_json::json;
+    use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn tmp_log_path() -> String {
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir()
+            .join(format!("authz_audit_{}_{}", std::process::id(), n));
+        fs::create_dir_all(&dir).unwrap();
+        dir.join("audit.ndjson").to_string_lossy().to_string()
+    }
+
+    fn parse_lines(path: &str) -> Vec<serde_json::Value> {
+        let content = fs::read_to_string(path).unwrap_or_default();
+        content
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| serde_json::from_str(l).expect("valid JSON line"))
+            .collect()
+    }
+
+    #[test]
+    fn write_allow_event_and_parse_back() {
+        let path = tmp_log_path();
+        log_allow(
+            &path,
+            "claude-code@0.3.2",
+            "ax_click",
+            &json!({ "backend_id": 42 }),
+            &Some("https://redandan.github.io/#/wallet".into()),
+            "ax_* url=redandan.github.io/**",
+        );
+
+        let lines = parse_lines(&path);
+        assert_eq!(lines.len(), 1);
+        let ev = &lines[0];
+        assert_eq!(ev["type"], "allow");
+        assert_eq!(ev["client"], "claude-code@0.3.2");
+        assert_eq!(ev["action"], "ax_click");
+        assert_eq!(ev["args"]["backend_id"], 42);
+        assert_eq!(ev["url"], "https://redandan.github.io/#/wallet");
+        assert_eq!(ev["rule"], "ax_* url=redandan.github.io/**");
+        // ts is present and non-empty
+        assert!(ev["ts"].as_str().map(|s| !s.is_empty()).unwrap_or(false));
+    }
+
+    #[test]
+    fn write_deny_event_and_parse_back() {
+        let path = tmp_log_path();
+        log_deny(
+            &path,
+            "claude-desktop@1.2.0",
+            "goto",
+            &json!({ "target": "https://paypal.com/login" }),
+            &Some("about:blank".into()),
+            "url=**paypal**",
+        );
+
+        let lines = parse_lines(&path);
+        assert_eq!(lines.len(), 1);
+        let ev = &lines[0];
+        assert_eq!(ev["type"], "deny");
+        assert_eq!(ev["action"], "goto");
+        assert_eq!(ev["args"]["target"], "https://paypal.com/login");
+    }
+
+    #[test]
+    fn write_ask_event_and_parse_back() {
+        let path = tmp_log_path();
+        log_ask(
+            &path,
+            "cursor@0.50",
+            "goto",
+            &json!({ "target": "https://google.com/oauth" }),
+            &Some("about:blank".into()),
+            "action=goto url=**.google.com/**",
+        );
+
+        let lines = parse_lines(&path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["type"], "ask");
+    }
+
+    #[test]
+    fn write_multiple_events_all_parseable() {
+        let path = tmp_log_path();
+        log_allow(&path, "a@1", "screenshot", &json!({}), &None, "readonly_allow");
+        log_deny(&path, "b@1", "eval", &json!({ "target": "document.cookie" }), &None, "js_contains=document.cookie");
+        log_ask(&path, "c@1", "goto", &json!({ "target": "https://google.com/" }), &None, "ask_rule");
+
+        let lines = parse_lines(&path);
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0]["type"], "allow");
+        assert_eq!(lines[1]["type"], "deny");
+        assert_eq!(lines[2]["type"], "ask");
+    }
+
+    #[test]
+    fn write_learn_event_and_parse_back() {
+        let path = tmp_log_path();
+        log_learn(
+            &path,
+            "claude-code@0.3.2",
+            &json!({ "action": "goto", "url_pattern": "https://docs.flutter.dev/**" }),
+            ".sirin/authz.yaml",
+        );
+
+        let lines = parse_lines(&path);
+        assert_eq!(lines.len(), 1);
+        let ev = &lines[0];
+        assert_eq!(ev["type"], "learn");
+        assert_eq!(ev["written_to"], ".sirin/authz.yaml");
+        assert_eq!(ev["new_rule"]["action"], "goto");
+    }
+
+    #[test]
+    fn creates_parent_dirs_if_missing() {
+        let dir = std::env::temp_dir().join(format!("authz_deep_{}", std::process::id()));
+        let path = dir.join("nested").join("deeply").join("audit.ndjson");
+        let path_str = path.to_string_lossy().to_string();
+
+        log_allow(&path_str, "test@1", "screenshot", &json!({}), &None, "readonly_allow");
+        assert!(path.exists(), "file should be created in nested dirs");
+    }
+
+    #[test]
+    fn url_none_writes_empty_string() {
+        let path = tmp_log_path();
+        log_allow(&path, "test@1", "ax_tree", &json!({}), &None, "readonly_allow");
+        let lines = parse_lines(&path);
+        assert_eq!(lines[0]["url"], "");
+    }
+}

--- a/src/authz/config.rs
+++ b/src/authz/config.rs
@@ -1,0 +1,519 @@
+/// Configuration schema and loader for the Pre-Authorization Engine.
+///
+/// Layer priority (highest wins):
+///   1. Repo-local  `.sirin/authz.yaml`
+///   2. User-global `~/.sirin/authz.yaml`
+///   3. Built-in hard-coded defaults (`defaults()`)
+///
+/// `allow` / `deny` / `ask` arrays are **unioned** across layers;
+/// `mode` is taken from the highest layer that sets it.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+// ─── Mode ────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Mode {
+    /// deny-by-default + allow-list + ask-list (default)
+    #[default]
+    Selective,
+    /// all mutating actions need human approval
+    Strict,
+    /// only hard deny-rules apply; everything else is allowed (dev / CI)
+    Permissive,
+    /// no mutating actions at all (AI can only plan, not act)
+    Plan,
+}
+
+// ─── Rule ────────────────────────────────────────────────────────────────────
+
+/// A single allow / deny / ask rule.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Rule {
+    /// Action name (supports `*` suffix like `ax_*`, or `*` for all).
+    #[serde(default)]
+    pub action: Option<String>,
+
+    /// URL glob (`*` = one segment, `**` = any number of segments).
+    #[serde(default)]
+    pub url_pattern: Option<String>,
+
+    /// For `eval` actions: JS source must contain this substring (case-insensitive).
+    #[serde(default)]
+    pub js_contains: Option<String>,
+
+    /// a11y name / value must contain this substring (case-insensitive).
+    #[serde(default)]
+    pub name_substring: Option<String>,
+
+    /// a11y name must match this regex.
+    #[serde(default)]
+    pub name_regex: Option<String>,
+
+    /// a11y name must NOT contain any of these substrings (case-insensitive).
+    /// Any one match → rule fires.
+    #[serde(default)]
+    pub not_name_matches: Vec<String>,
+}
+
+impl Rule {
+    /// Human-readable summary for logging / reasons.
+    pub fn describe(&self) -> String {
+        let mut parts = Vec::new();
+        if let Some(a) = &self.action {
+            parts.push(format!("action={a}"));
+        }
+        if let Some(u) = &self.url_pattern {
+            parts.push(format!("url={u}"));
+        }
+        if let Some(js) = &self.js_contains {
+            parts.push(format!("js_contains={js}"));
+        }
+        if let Some(nm) = &self.name_substring {
+            parts.push(format!("name_substring={nm}"));
+        }
+        if let Some(nr) = &self.name_regex {
+            parts.push(format!("name_regex={nr}"));
+        }
+        if !self.not_name_matches.is_empty() {
+            parts.push(format!("not_name_matches={:?}", self.not_name_matches));
+        }
+        if parts.is_empty() {
+            "rule(any)".to_string()
+        } else {
+            parts.join(" ")
+        }
+    }
+}
+
+// ─── ClientPolicy ────────────────────────────────────────────────────────────
+
+/// Per-client policy override (only `mode` for now; future: extra allow/deny).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ClientPolicy {
+    #[serde(default)]
+    pub mode: Option<Mode>,
+}
+
+// ─── LearnConfig ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LearnConfig {
+    #[serde(default = "bool_false")]
+    pub enabled: bool,
+
+    #[serde(default = "default_write_back")]
+    pub write_back_to: String,
+
+    #[serde(default = "default_max_asks")]
+    pub max_asks_per_session: u32,
+}
+
+impl Default for LearnConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            write_back_to: default_write_back(),
+            max_asks_per_session: default_max_asks(),
+        }
+    }
+}
+
+fn bool_false() -> bool { false }
+fn default_write_back() -> String { "repo".to_string() }
+fn default_max_asks() -> u32 { 20 }
+
+// ─── AuditConfig ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditConfig {
+    #[serde(default = "default_log_path")]
+    pub log_path: String,
+
+    #[serde(default = "default_max_size_mb")]
+    pub max_size_mb: u64,
+
+    #[serde(default = "default_max_backups")]
+    pub max_backups: u32,
+}
+
+impl Default for AuditConfig {
+    fn default() -> Self {
+        Self {
+            log_path: default_log_path(),
+            max_size_mb: default_max_size_mb(),
+            max_backups: default_max_backups(),
+        }
+    }
+}
+
+fn default_log_path() -> String { ".sirin/audit.ndjson".to_string() }
+fn default_max_size_mb() -> u64 { 10 }
+fn default_max_backups() -> u32 { 5 }
+
+// ─── AuthzConfig ─────────────────────────────────────────────────────────────
+
+/// Top-level configuration struct (matches the YAML schema).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AuthzConfig {
+    /// Global default mode (overridden per-client if client has `mode`).
+    #[serde(default)]
+    pub mode: Mode,
+
+    /// Actions that are always allowed regardless of mode / rules.
+    #[serde(default = "default_readonly_allow")]
+    pub readonly_allow: Vec<String>,
+
+    /// Per-client overrides keyed by `<name>@<version>` glob.
+    #[serde(default)]
+    pub clients: std::collections::HashMap<String, ClientPolicy>,
+
+    /// Allow-list rules.
+    #[serde(default)]
+    pub allow: Vec<Rule>,
+
+    /// Hard-deny rules (evaluated before allow).
+    #[serde(default)]
+    pub deny: Vec<Rule>,
+
+    /// Prompt-human rules.
+    #[serde(default)]
+    pub ask: Vec<Rule>,
+
+    #[serde(default)]
+    pub learn: LearnConfig,
+
+    #[serde(default)]
+    pub audit: AuditConfig,
+}
+
+fn default_readonly_allow() -> Vec<String> {
+    vec![
+        "ax_tree".into(), "ax_find".into(), "ax_value".into(),
+        "screenshot".into(), "url".into(), "title".into(),
+        "console".into(), "network".into(), "exists".into(),
+        "attr".into(), "read".into(),
+    ]
+}
+
+impl AuthzConfig {
+    /// Resolve which `Mode` applies for a given client id (e.g. `claude-code@0.3.2`).
+    ///
+    /// Matching order:
+    ///   1. Exact key match
+    ///   2. `<name>@*` wildcard
+    ///   3. `*` catch-all
+    ///   4. Global `mode` field
+    pub fn resolve_mode(&self, client_id: &str) -> Mode {
+        // Exact
+        if let Some(cp) = self.clients.get(client_id) {
+            if let Some(m) = &cp.mode {
+                return m.clone();
+            }
+        }
+
+        // Wildcard: try replacing version with `*`
+        let name_part = client_id.split('@').next().unwrap_or(client_id);
+        let wildcard = format!("{name_part}@*");
+        if let Some(cp) = self.clients.get(&wildcard) {
+            if let Some(m) = &cp.mode {
+                return m.clone();
+            }
+        }
+
+        // Catch-all
+        if let Some(cp) = self.clients.get("*") {
+            if let Some(m) = &cp.mode {
+                return m.clone();
+            }
+        }
+
+        self.mode.clone()
+    }
+}
+
+// ─── Defaults ────────────────────────────────────────────────────────────────
+
+/// Built-in hard-coded baseline (loaded when no YAML file exists).
+pub fn defaults() -> AuthzConfig {
+    AuthzConfig {
+        mode: Mode::Selective,
+        readonly_allow: default_readonly_allow(),
+        clients: std::collections::HashMap::new(),
+        allow: vec![],
+        deny: vec![
+            Rule { url_pattern: Some("file:///**".into()), ..Default::default() },
+            Rule { url_pattern: Some("chrome://**".into()), ..Default::default() },
+            Rule { url_pattern: Some("chrome-extension://**".into()), ..Default::default() },
+            Rule { action: Some("eval".into()), js_contains: Some("document.cookie".into()), ..Default::default() },
+            Rule { action: Some("eval".into()), js_contains: Some("window.ethereum".into()), ..Default::default() },
+            Rule { action: Some("eval".into()), js_contains: Some("navigator.credentials".into()), ..Default::default() },
+            Rule { action: Some("eval".into()), js_contains: Some("indexedDB.open".into()), ..Default::default() },
+            Rule {
+                action: Some("ax_type*".into()),
+                not_name_matches: vec![
+                    "password".into(), "密碼".into(),
+                    "private key".into(), "seed phrase".into(), "助記詞".into(),
+                ],
+                ..Default::default()
+            },
+        ],
+        ask: vec![],
+        learn: LearnConfig::default(),
+        audit: AuditConfig::default(),
+    }
+}
+
+impl Default for Rule {
+    fn default() -> Self {
+        Rule {
+            action: None,
+            url_pattern: None,
+            js_contains: None,
+            name_substring: None,
+            name_regex: None,
+            not_name_matches: vec![],
+        }
+    }
+}
+
+// ─── Loader ──────────────────────────────────────────────────────────────────
+
+/// Load and merge all config layers:
+///   built-in defaults ← user-global ← repo-local
+///
+/// `repo_root` should be the directory that contains `.sirin/authz.yaml` (if any).
+/// Pass `None` to skip repo-local layer.
+pub fn load(repo_root: Option<&Path>) -> AuthzConfig {
+    let mut cfg = defaults();
+
+    // User-global: ~/.sirin/authz.yaml
+    if let Some(home) = dirs_home() {
+        let user_path = home.join(".sirin").join("authz.yaml");
+        if user_path.exists() {
+            if let Ok(extra) = load_file(&user_path) {
+                merge_into(&mut cfg, extra);
+            }
+        }
+    }
+
+    // Repo-local: <repo>/.sirin/authz.yaml
+    if let Some(root) = repo_root {
+        let repo_path = root.join(".sirin").join("authz.yaml");
+        if repo_path.exists() {
+            if let Ok(extra) = load_file(&repo_path) {
+                merge_into(&mut cfg, extra);
+            }
+        }
+    }
+
+    cfg
+}
+
+/// Parse a single YAML file into `AuthzConfig`. Returns `Err(String)` on failure.
+pub fn load_file(path: &Path) -> Result<AuthzConfig, String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("authz: cannot read {}: {e}", path.display()))?;
+    serde_yaml::from_str::<AuthzConfig>(&text)
+        .map_err(|e| format!("authz: parse error in {}: {e}", path.display()))
+}
+
+/// Merge `src` (higher-priority layer) into `base`:
+///   - `allow` / `deny` / `ask` arrays are prepended (src rules take precedence).
+///   - `mode` is taken from `src` if not equal to default `Selective`.
+///   - `readonly_allow` union (src items that aren't already present get appended).
+///   - `clients` map: `src` entries overwrite `base` entries.
+pub fn merge_into(base: &mut AuthzConfig, src: AuthzConfig) {
+    // mode: let higher-priority layer override
+    // (we treat src.mode as intentional if the file sets it)
+    base.mode = src.mode;
+
+    // readonly_allow: union
+    for item in src.readonly_allow {
+        if !base.readonly_allow.contains(&item) {
+            base.readonly_allow.push(item);
+        }
+    }
+
+    // rules: src rules go first so they match before base rules
+    let mut new_allow = src.allow;
+    new_allow.extend(std::mem::take(&mut base.allow));
+    base.allow = new_allow;
+
+    let mut new_deny = src.deny;
+    new_deny.extend(std::mem::take(&mut base.deny));
+    base.deny = new_deny;
+
+    let mut new_ask = src.ask;
+    new_ask.extend(std::mem::take(&mut base.ask));
+    base.ask = new_ask;
+
+    // clients: src entries overwrite
+    for (k, v) in src.clients {
+        base.clients.insert(k, v);
+    }
+
+    // learn / audit: src overrides
+    base.learn = src.learn;
+    base.audit = src.audit;
+}
+
+fn dirs_home() -> Option<std::path::PathBuf> {
+    std::env::var("HOME")
+        .ok()
+        .map(std::path::PathBuf::from)
+        .or_else(|| std::env::var("USERPROFILE").ok().map(std::path::PathBuf::from))
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod config_test {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn tmp_dir() -> PathBuf {
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let d = std::env::temp_dir()
+            .join(format!("authz_cfg_{}_{}", std::process::id(), n));
+        fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn write_yaml(dir: &PathBuf, name: &str, yaml: &str) {
+        let sirin_dir = dir.join(".sirin");
+        fs::create_dir_all(&sirin_dir).unwrap();
+        fs::write(sirin_dir.join(name), yaml).unwrap();
+    }
+
+    // ── round-trip ────────────────────────────────────────────────────────────
+    #[test]
+    fn yaml_roundtrip_defaults() {
+        let cfg = defaults();
+        let yaml = serde_yaml::to_string(&cfg).expect("serialize");
+        let back: AuthzConfig = serde_yaml::from_str(&yaml).expect("deserialize");
+        assert_eq!(back.mode, Mode::Selective);
+        assert!(back.readonly_allow.contains(&"screenshot".to_string()));
+        assert!(!back.deny.is_empty());
+    }
+
+    #[test]
+    fn yaml_roundtrip_minimal() {
+        let yaml = "mode: permissive\n";
+        let cfg: AuthzConfig = serde_yaml::from_str(yaml).expect("deserialize");
+        assert_eq!(cfg.mode, Mode::Permissive);
+        // readonly_allow uses serde(default) so it should be populated
+        assert!(cfg.readonly_allow.contains(&"ax_tree".to_string()));
+    }
+
+    // ── three-layer merge ─────────────────────────────────────────────────────
+    #[test]
+    fn merge_repo_overrides_mode() {
+        let dir = tmp_dir();
+        write_yaml(&dir, "authz.yaml", "mode: strict\n");
+        let cfg = load(Some(&dir));
+        assert_eq!(cfg.mode, Mode::Strict);
+    }
+
+    #[test]
+    fn merge_deny_union() {
+        // repo layer adds an extra deny rule; both repo + default deny rules present
+        let dir = tmp_dir();
+        let yaml = r#"
+deny:
+  - { url_pattern: "https://evil.example/**" }
+"#;
+        write_yaml(&dir, "authz.yaml", yaml);
+        let cfg = load(Some(&dir));
+        // Repo rule prepended
+        assert_eq!(cfg.deny[0].url_pattern.as_deref(), Some("https://evil.example/**"));
+        // Built-in defaults still present
+        let has_file_deny = cfg.deny.iter().any(|r| r.url_pattern.as_deref() == Some("file:///**"));
+        assert!(has_file_deny, "built-in file:// deny should survive merge");
+    }
+
+    #[test]
+    fn merge_allow_union() {
+        let dir = tmp_dir();
+        let yaml = r#"
+allow:
+  - { action: goto, url_pattern: "http://localhost:3000/**" }
+"#;
+        write_yaml(&dir, "authz.yaml", yaml);
+        let cfg = load(Some(&dir));
+        // defaults() has empty allow; repo rule is present
+        let has_local = cfg.allow.iter().any(|r| {
+            r.url_pattern.as_deref() == Some("http://localhost:3000/**")
+        });
+        assert!(has_local);
+    }
+
+    // ── glob edge cases ───────────────────────────────────────────────────────
+    #[test]
+    fn glob_double_star_matches_path() {
+        // Validate that our rule struct deserialises glob correctly
+        let yaml = r#"
+allow:
+  - { action: goto, url_pattern: "https://redandan.github.io/**" }
+"#;
+        let cfg: AuthzConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            cfg.allow[0].url_pattern.as_deref(),
+            Some("https://redandan.github.io/**")
+        );
+    }
+
+    #[test]
+    fn glob_single_star_segment() {
+        let yaml = r#"
+allow:
+  - { action: goto, url_pattern: "http://localhost:*/**" }
+"#;
+        let cfg: AuthzConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            cfg.allow[0].url_pattern.as_deref(),
+            Some("http://localhost:*/**")
+        );
+    }
+
+    #[test]
+    fn glob_exact_string() {
+        let yaml = r#"
+deny:
+  - { url_pattern: "https://evil.example/exact" }
+"#;
+        let cfg: AuthzConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            cfg.deny[0].url_pattern.as_deref(),
+            Some("https://evil.example/exact")
+        );
+    }
+
+    #[test]
+    fn readonly_allow_default_populated() {
+        let yaml = "mode: selective\n";
+        let cfg: AuthzConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.readonly_allow.contains(&"ax_tree".to_string()));
+        assert!(cfg.readonly_allow.contains(&"screenshot".to_string()));
+    }
+
+    #[test]
+    fn client_policy_merge() {
+        let yaml = r#"
+clients:
+  "claude-code@*":
+    mode: permissive
+  "*":
+    mode: selective
+"#;
+        let cfg: AuthzConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.resolve_mode("claude-code@0.3.2"), Mode::Permissive);
+        assert_eq!(cfg.resolve_mode("unknown@1.0"), Mode::Selective);
+    }
+}

--- a/src/authz/engine.rs
+++ b/src/authz/engine.rs
@@ -1,0 +1,634 @@
+/// Decision engine: `decide()` + rule pattern matching.
+///
+/// Algorithm (§5 of DESIGN_AUTHZ.md):
+///   1. readonly_allow direct pass
+///   2. deny (highest priority, evaluated before allow)
+///   3. mode dispatch (Permissive / Plan / Strict short-circuits)
+///   4. allow check
+///   5. ask check
+///   6. learn path (not implemented — stub)
+///   7. default deny
+
+use serde_json::Value as JsonValue;
+
+use crate::authz::config::{AuthzConfig, Mode, Rule};
+
+// ─── Decision ────────────────────────────────────────────────────────────────
+
+/// The outcome of a single authorization check.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Decision {
+    /// The action is allowed. Contains a human-readable reason string.
+    Allow(String),
+    /// The action is denied. Contains a human-readable reason string.
+    Deny(String),
+    /// A human must be asked (sync/async prompt). Contains reason string.
+    Ask(String),
+    /// Like `Ask` but the user gets "Allow always" / learn options.
+    AskWithLearn,
+}
+
+// ─── decide() ────────────────────────────────────────────────────────────────
+
+/// Core authorization decision function.
+///
+/// # Parameters
+/// - `client_id`: MCP client identifier like `claude-code@0.3.2`
+/// - `action`:    MCP browser_exec action name (e.g. `goto`, `ax_click`)
+/// - `args`:      Full args JSON object for the call
+/// - `current_url`: Current browser URL (may be `None` if browser is closed)
+/// - `config`:    Loaded and merged `AuthzConfig`
+pub fn decide(
+    client_id: &str,
+    action: &str,
+    args: &JsonValue,
+    current_url: &Option<String>,
+    config: &AuthzConfig,
+) -> Decision {
+    // 1. readonly_allow: zero-risk actions pass unconditionally
+    if config.readonly_allow.iter().any(|ra| ra == action) {
+        return Decision::Allow("readonly_allow".to_string());
+    }
+
+    // 2. deny: evaluated before everything else
+    for rule in &config.deny {
+        if rule_matches(rule, action, args, current_url) {
+            return Decision::Deny(rule.describe());
+        }
+    }
+
+    // 3. mode dispatch
+    let mode = config.resolve_mode(client_id);
+    match mode {
+        Mode::Permissive => {
+            return Decision::Allow("permissive mode".to_string());
+        }
+        Mode::Plan => {
+            if is_mutating(action) {
+                return Decision::Deny("plan mode — mutating action disabled".to_string());
+            }
+            return Decision::Allow("plan mode readonly".to_string());
+        }
+        Mode::Strict => {
+            if is_mutating(action) {
+                return Decision::Ask("strict mode — all mutating actions require approval".to_string());
+            }
+            return Decision::Allow("strict mode readonly".to_string());
+        }
+        Mode::Selective => {
+            // continue to allow / ask / learn / default-deny below
+        }
+    }
+
+    // 4. allow
+    for rule in &config.allow {
+        if rule_matches(rule, action, args, current_url) {
+            return Decision::Allow(rule.describe());
+        }
+    }
+
+    // 5. ask
+    for rule in &config.ask {
+        if rule_matches(rule, action, args, current_url) {
+            return Decision::Ask(rule.describe());
+        }
+    }
+
+    // 6. learn mode (not implemented in this PR — TODO: wire to Monitor channel)
+    if config.learn.enabled {
+        return Decision::AskWithLearn;
+    }
+
+    // 7. default deny
+    Decision::Deny("no matching allow rule".to_string())
+}
+
+// ─── Rule matching ───────────────────────────────────────────────────────────
+
+/// Returns `true` if a rule matches the given call parameters.
+///
+/// All specified fields must match (logical AND).
+/// Unspecified (None / empty) fields are treated as wildcard (always match).
+pub fn rule_matches(
+    rule: &Rule,
+    action: &str,
+    args: &JsonValue,
+    current_url: &Option<String>,
+) -> bool {
+    // action field
+    if let Some(rule_action) = &rule.action {
+        if !action_matches(rule_action, action) {
+            return false;
+        }
+    }
+
+    // url_pattern field
+    if let Some(pattern) = &rule.url_pattern {
+        let url = resolve_url(args, current_url);
+        if !glob_matches(pattern, &url) {
+            return false;
+        }
+    }
+
+    // js_contains (case-insensitive substring in args.target or args.js or args.script)
+    if let Some(needle) = &rule.js_contains {
+        let js_text = extract_js_text(args);
+        if !js_text.to_lowercase().contains(&needle.to_lowercase()) {
+            return false;
+        }
+    }
+
+    // name_substring (case-insensitive)
+    if let Some(needle) = &rule.name_substring {
+        let name_text = extract_name_text(args);
+        if !name_text.to_lowercase().contains(&needle.to_lowercase()) {
+            return false;
+        }
+    }
+
+    // name_regex
+    if let Some(pattern) = &rule.name_regex {
+        let name_text = extract_name_text(args);
+        match regex::Regex::new(pattern) {
+            Ok(re) => {
+                if !re.is_match(&name_text) {
+                    return false;
+                }
+            }
+            Err(_) => {
+                // invalid regex → treat as non-matching (fail open for allow, fail closed for deny)
+                return false;
+            }
+        }
+    }
+
+    // not_name_matches: action fires if ANY substring matches (for deny rules).
+    // If the rule has not_name_matches, the rule matches when name does NOT contain any of them.
+    // This is the "deny if name contains forbidden word" semantics:
+    //   deny rule fires = the action targets a sensitive field.
+    if !rule.not_name_matches.is_empty() {
+        let name_text = extract_name_text(args);
+        let name_lower = name_text.to_lowercase();
+        // The rule matches (fires) if any forbidden word is found in the name.
+        let any_forbidden = rule.not_name_matches.iter()
+            .any(|s| name_lower.contains(&s.to_lowercase()));
+        if !any_forbidden {
+            return false;
+        }
+    }
+
+    true
+}
+
+// ─── Action wildcard matching ─────────────────────────────────────────────────
+
+/// Matches action names: supports `*` (match all), `prefix_*` (prefix wildcard),
+/// `*_suffix` (suffix wildcard), or exact match.
+fn action_matches(pattern: &str, action: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        return action.starts_with(prefix);
+    }
+    if let Some(suffix) = pattern.strip_prefix('*') {
+        return action.ends_with(suffix);
+    }
+    pattern == action
+}
+
+// ─── URL resolution ───────────────────────────────────────────────────────────
+
+/// Resolve the URL to check: prefer `args.target` (for `goto`),
+/// then `args.url`, then fall back to `current_url`.
+fn resolve_url(args: &JsonValue, current_url: &Option<String>) -> String {
+    if let Some(t) = args.get("target").and_then(|v| v.as_str()) {
+        return t.to_string();
+    }
+    if let Some(u) = args.get("url").and_then(|v| v.as_str()) {
+        return u.to_string();
+    }
+    current_url.clone().unwrap_or_default()
+}
+
+// ─── Glob matching ────────────────────────────────────────────────────────────
+
+/// Matches a URL against a glob pattern using the `globset` crate.
+/// Falls back to `false` on invalid pattern (fail-safe for allow; still blocks for deny).
+fn glob_matches(pattern: &str, url: &str) -> bool {
+    use globset::GlobBuilder;
+
+    // Build a glob that matches case-insensitively and treats `**` as any path segment.
+    let glob = GlobBuilder::new(pattern)
+        .case_insensitive(false)
+        .literal_separator(false) // `*` can match separators (needed for URL paths)
+        .build();
+
+    match glob {
+        Ok(g) => {
+            let matcher = g.compile_matcher();
+            matcher.is_match(url)
+        }
+        Err(_) => false,
+    }
+}
+
+// ─── JS text extraction ───────────────────────────────────────────────────────
+
+/// Extract JS source text from args for eval-type actions.
+fn extract_js_text(args: &JsonValue) -> String {
+    // Try common field names used by browser_exec eval
+    for key in &["target", "js", "script", "expression"] {
+        if let Some(s) = args.get(*key).and_then(|v| v.as_str()) {
+            return s.to_string();
+        }
+    }
+    String::new()
+}
+
+// ─── Name text extraction ─────────────────────────────────────────────────────
+
+/// Extract a11y name / label text from args for ax_* actions.
+fn extract_name_text(args: &JsonValue) -> String {
+    for key in &["name", "label", "text", "value", "target"] {
+        if let Some(s) = args.get(*key).and_then(|v| v.as_str()) {
+            return s.to_string();
+        }
+    }
+    String::new()
+}
+
+// ─── Mutating action detection ───────────────────────────────────────────────
+
+/// Returns `true` for actions that change browser state / page content.
+/// Read-only actions (ax_tree, screenshot, url, etc.) return `false`.
+pub fn is_mutating(action: &str) -> bool {
+    // Explicitly non-mutating
+    const READONLY: &[&str] = &[
+        "ax_tree", "ax_find", "ax_value", "screenshot", "url", "title",
+        "console", "network", "exists", "attr", "read",
+    ];
+    if READONLY.contains(&action) {
+        return false;
+    }
+    // Everything else is considered mutating
+    true
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod engine_test {
+    use super::*;
+    use crate::authz::config::{AuditConfig, ClientPolicy, LearnConfig, Rule};
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    fn base_config() -> AuthzConfig {
+        crate::authz::config::defaults()
+    }
+
+    fn selective_config_with_allow(allow: Vec<Rule>) -> AuthzConfig {
+        AuthzConfig {
+            mode: Mode::Selective,
+            readonly_allow: vec![
+                "ax_tree".into(), "screenshot".into(), "url".into(),
+            ],
+            allow,
+            deny: vec![],
+            ask: vec![],
+            clients: HashMap::new(),
+            learn: LearnConfig::default(),
+            audit: AuditConfig::default(),
+        }
+    }
+
+    // ── 1. readonly_allow direct pass ─────────────────────────────────────────
+    #[test]
+    fn readonly_allow_passes() {
+        let cfg = base_config();
+        let d = decide("test@1.0", "ax_tree", &json!({}), &None, &cfg);
+        assert_eq!(d, Decision::Allow("readonly_allow".to_string()));
+    }
+
+    #[test]
+    fn readonly_allow_screenshot_passes() {
+        let cfg = base_config();
+        let d = decide("test@1.0", "screenshot", &json!({}), &None, &cfg);
+        assert_eq!(d, Decision::Allow("readonly_allow".to_string()));
+    }
+
+    // ── 2. deny priority over allow ───────────────────────────────────────────
+    #[test]
+    fn deny_priority_over_allow() {
+        let mut cfg = selective_config_with_allow(vec![
+            Rule { action: Some("goto".into()), url_pattern: Some("**".into()), ..Default::default() },
+        ]);
+        cfg.deny.push(Rule {
+            url_pattern: Some("https://**paypal**/**".into()),
+            ..Default::default()
+        });
+        let d = decide(
+            "test@1.0",
+            "goto",
+            &json!({ "target": "https://www.paypal.com/login" }),
+            &None,
+            &cfg,
+        );
+        matches!(d, Decision::Deny(_));
+    }
+
+    #[test]
+    fn deny_eval_js_contains_cookie() {
+        let cfg = base_config();
+        let d = decide(
+            "test@1.0",
+            "eval",
+            &json!({ "target": "return document.cookie;" }),
+            &None,
+            &cfg,
+        );
+        assert!(matches!(d, Decision::Deny(_)), "got {d:?}");
+    }
+
+    #[test]
+    fn deny_eval_ethereum() {
+        let cfg = base_config();
+        let d = decide(
+            "test@1.0",
+            "eval",
+            &json!({ "target": "window.ethereum.request({method:'eth_accounts'})" }),
+            &None,
+            &cfg,
+        );
+        assert!(matches!(d, Decision::Deny(_)), "got {d:?}");
+    }
+
+    // ── 3. Mode::Permissive ───────────────────────────────────────────────────
+    #[test]
+    fn mode_permissive_allows_all() {
+        let cfg = AuthzConfig {
+            mode: Mode::Permissive,
+            readonly_allow: vec![],
+            allow: vec![],
+            deny: vec![],
+            ask: vec![],
+            clients: HashMap::new(),
+            learn: LearnConfig::default(),
+            audit: AuditConfig::default(),
+        };
+        let d = decide("test@1.0", "goto", &json!({ "target": "https://example.com/" }), &None, &cfg);
+        assert_eq!(d, Decision::Allow("permissive mode".to_string()));
+    }
+
+    // ── 4. Mode::Plan ────────────────────────────────────────────────────────
+    #[test]
+    fn mode_plan_denies_mutating() {
+        let cfg = AuthzConfig {
+            mode: Mode::Plan,
+            ..AuthzConfig::default()
+        };
+        let d = decide("test@1.0", "goto", &json!({ "target": "https://example.com/" }), &None, &cfg);
+        assert!(matches!(d, Decision::Deny(_)), "got {d:?}");
+    }
+
+    #[test]
+    fn mode_plan_allows_readonly() {
+        let cfg = AuthzConfig {
+            mode: Mode::Plan,
+            readonly_allow: vec!["ax_tree".into()],
+            ..AuthzConfig::default()
+        };
+        // ax_tree is in readonly_allow so hits step 1 before mode check
+        let d = decide("test@1.0", "ax_tree", &json!({}), &None, &cfg);
+        assert_eq!(d, Decision::Allow("readonly_allow".to_string()));
+    }
+
+    #[test]
+    fn mode_plan_allows_non_mutating_non_readonly() {
+        // A hypothetical action not in readonly_allow but also not mutating
+        let cfg = AuthzConfig {
+            mode: Mode::Plan,
+            readonly_allow: vec![],
+            deny: vec![],
+            allow: vec![],
+            ask: vec![],
+            clients: HashMap::new(),
+            learn: LearnConfig::default(),
+            audit: AuditConfig::default(),
+        };
+        // "url" is in default readonly_allow but not in this custom cfg
+        // Use a truly non-mutating action that is not in readonly list
+        // Plan mode: is_mutating("url") == false → allow
+        let d = decide("test@1.0", "url", &json!({}), &None, &cfg);
+        assert_eq!(d, Decision::Allow("plan mode readonly".to_string()));
+    }
+
+    // ── 5. Mode::Strict ───────────────────────────────────────────────────────
+    #[test]
+    fn mode_strict_asks_mutating() {
+        let cfg = AuthzConfig {
+            mode: Mode::Strict,
+            readonly_allow: vec![],
+            deny: vec![],
+            allow: vec![],
+            ask: vec![],
+            clients: HashMap::new(),
+            learn: LearnConfig::default(),
+            audit: AuditConfig::default(),
+        };
+        let d = decide("test@1.0", "goto", &json!({ "target": "https://example.com/" }), &None, &cfg);
+        assert!(matches!(d, Decision::Ask(_)), "got {d:?}");
+    }
+
+    #[test]
+    fn mode_strict_allows_readonly() {
+        let cfg = AuthzConfig {
+            mode: Mode::Strict,
+            readonly_allow: vec![],
+            deny: vec![],
+            allow: vec![],
+            ask: vec![],
+            clients: HashMap::new(),
+            learn: LearnConfig::default(),
+            audit: AuditConfig::default(),
+        };
+        // is_mutating("ax_tree") == false → strict mode allows
+        let d = decide("test@1.0", "ax_tree", &json!({}), &None, &cfg);
+        assert_eq!(d, Decision::Allow("strict mode readonly".to_string()));
+    }
+
+    // ── 6. Mode::Selective allow rule ────────────────────────────────────────
+    #[test]
+    fn selective_allow_url_match() {
+        let cfg = selective_config_with_allow(vec![
+            Rule {
+                action: Some("goto".into()),
+                url_pattern: Some("https://redandan.github.io/**".into()),
+                ..Default::default()
+            },
+        ]);
+        let d = decide(
+            "test@1.0",
+            "goto",
+            &json!({ "target": "https://redandan.github.io/app/#/home" }),
+            &None,
+            &cfg,
+        );
+        assert!(matches!(d, Decision::Allow(_)), "got {d:?}");
+    }
+
+    #[test]
+    fn selective_allow_action_wildcard_ax_star() {
+        let cfg = selective_config_with_allow(vec![
+            Rule {
+                action: Some("ax_*".into()),
+                url_pattern: Some("http://localhost:*/**".into()),
+                ..Default::default()
+            },
+        ]);
+        let d = decide(
+            "test@1.0",
+            "ax_click",
+            &json!({ "backend_id": 42 }),
+            &Some("http://localhost:3000/test".into()),
+            &cfg,
+        );
+        assert!(matches!(d, Decision::Allow(_)), "got {d:?}");
+    }
+
+    // ── 7. ask rule ───────────────────────────────────────────────────────────
+    #[test]
+    fn selective_ask_rule() {
+        let cfg = AuthzConfig {
+            mode: Mode::Selective,
+            readonly_allow: vec![],
+            deny: vec![],
+            allow: vec![],
+            ask: vec![
+                Rule {
+                    action: Some("goto".into()),
+                    url_pattern: Some("https://**.google.com/**".into()),
+                    ..Default::default()
+                },
+            ],
+            clients: HashMap::new(),
+            learn: LearnConfig::default(),
+            audit: AuditConfig::default(),
+        };
+        let d = decide(
+            "test@1.0",
+            "goto",
+            &json!({ "target": "https://accounts.google.com/oauth" }),
+            &None,
+            &cfg,
+        );
+        assert!(matches!(d, Decision::Ask(_)), "got {d:?}");
+    }
+
+    // ── 8. learn mode AskWithLearn ────────────────────────────────────────────
+    #[test]
+    fn learn_mode_returns_ask_with_learn() {
+        let cfg = AuthzConfig {
+            mode: Mode::Selective,
+            readonly_allow: vec![],
+            deny: vec![],
+            allow: vec![],
+            ask: vec![],
+            clients: HashMap::new(),
+            learn: LearnConfig { enabled: true, ..LearnConfig::default() },
+            audit: AuditConfig::default(),
+        };
+        let d = decide("test@1.0", "goto", &json!({ "target": "https://new.example.com/" }), &None, &cfg);
+        assert_eq!(d, Decision::AskWithLearn);
+    }
+
+    // ── 9. default deny ───────────────────────────────────────────────────────
+    #[test]
+    fn default_deny_no_rule() {
+        let cfg = selective_config_with_allow(vec![]);
+        let d = decide("test@1.0", "goto", &json!({ "target": "https://unknown.example/" }), &None, &cfg);
+        assert!(matches!(d, Decision::Deny(_)), "got {d:?}");
+    }
+
+    // ── 10. not_name_matches ──────────────────────────────────────────────────
+    #[test]
+    fn deny_not_name_matches_password() {
+        // Rule: deny ax_type when target name contains "password"
+        let mut cfg = selective_config_with_allow(vec![]);
+        cfg.deny.push(Rule {
+            action: Some("ax_type*".into()),
+            not_name_matches: vec!["password".into()],
+            ..Default::default()
+        });
+        let d = decide(
+            "test@1.0",
+            "ax_type",
+            &json!({ "name": "Enter your password" }),
+            &None,
+            &cfg,
+        );
+        assert!(matches!(d, Decision::Deny(_)), "got {d:?}");
+    }
+
+    #[test]
+    fn deny_not_name_matches_does_not_fire_for_safe_name() {
+        let mut cfg = selective_config_with_allow(vec![
+            Rule { action: Some("ax_type".into()), url_pattern: Some("**".into()), ..Default::default() },
+        ]);
+        cfg.deny.push(Rule {
+            action: Some("ax_type*".into()),
+            not_name_matches: vec!["password".into()],
+            ..Default::default()
+        });
+        let d = decide(
+            "test@1.0",
+            "ax_type",
+            &json!({ "name": "Username" }),
+            &None,
+            &cfg,
+        );
+        // deny rule does not fire; allow rule matches
+        assert!(matches!(d, Decision::Allow(_)), "got {d:?}");
+    }
+
+    // ── 11. client policy permissive override ─────────────────────────────────
+    #[test]
+    fn client_policy_permissive_overrides_selective() {
+        let mut clients = HashMap::new();
+        clients.insert("claude-code@*".into(), ClientPolicy { mode: Some(Mode::Permissive) });
+        let cfg = AuthzConfig {
+            mode: Mode::Selective,
+            readonly_allow: vec![],
+            deny: vec![],
+            allow: vec![],
+            ask: vec![],
+            clients,
+            learn: LearnConfig::default(),
+            audit: AuditConfig::default(),
+        };
+        let d = decide("claude-code@0.3.2", "goto", &json!({ "target": "https://anywhere.com/" }), &None, &cfg);
+        assert_eq!(d, Decision::Allow("permissive mode".to_string()));
+    }
+
+    // ── Glob matching edge cases ──────────────────────────────────────────────
+    #[test]
+    fn glob_double_star_matches_deep_path() {
+        assert!(glob_matches("https://redandan.github.io/**", "https://redandan.github.io/app/#/wallet/withdraw"));
+    }
+
+    #[test]
+    fn glob_single_star_port_wildcard() {
+        assert!(glob_matches("http://localhost:*/**", "http://localhost:3000/dashboard"));
+    }
+
+    #[test]
+    fn glob_no_match() {
+        assert!(!glob_matches("https://safe.example.com/**", "https://evil.example.com/page"));
+    }
+
+    #[test]
+    fn glob_double_star_paypal() {
+        assert!(glob_matches("https://**paypal**/**", "https://www.paypal.com/login"));
+    }
+}

--- a/src/authz/mod.rs
+++ b/src/authz/mod.rs
@@ -1,0 +1,74 @@
+/// Pre-Authorization Engine — public API entry point.
+///
+/// Usage from `mcp_server.rs` (T4):
+///
+/// ```rust,ignore
+/// use crate::authz::{AuthzConfig, Decision, decide, audit};
+///
+/// let cfg = authz::global_config();
+/// let decision = authz::decide(
+///     &client_id, &action, &args, &browser::current_url(), &cfg,
+/// );
+/// match &decision {
+///     Decision::Allow(reason) => {
+///         audit::log_allow(&cfg.audit.log_path, &client_id, &action, &args, &url, reason);
+///     }
+///     Decision::Deny(reason) => {
+///         audit::log_deny(&cfg.audit.log_path, &client_id, &action, &args, &url, reason);
+///         return mcp_error(format!("authz deny: {reason}"), ...);
+///     }
+///     Decision::Ask(_) | Decision::AskWithLearn => {
+///         // TODO T4: wire to Monitor GUI; for now treat as deny
+///         audit::log_ask(&cfg.audit.log_path, &client_id, &action, &args, &url, "ask→deny(no gui)");
+///         return mcp_error("authz ask — no GUI attached, treated as deny", ...);
+///     }
+/// }
+/// ```
+
+pub mod audit;
+pub mod config;
+pub mod engine;
+
+// Re-export the most-used public surface.
+// These will be used by mcp_server.rs in T4; suppress unused-import lint until then.
+#[allow(unused_imports)]
+pub use config::{AuthzConfig, Mode, Rule};
+#[allow(unused_imports)]
+pub use engine::{decide, Decision};
+
+use std::sync::Mutex;
+
+// ─── Global config ────────────────────────────────────────────────────────────
+
+/// Process-wide loaded config.
+/// Initialized lazily on first call to `global_config()` or `init()`.
+static GLOBAL_CONFIG: Mutex<Option<AuthzConfig>> = Mutex::new(None);
+
+/// Return a clone of the process-wide `AuthzConfig`.
+///
+/// If `init()` has not been called yet, loads with `repo_root = None`
+/// (built-in defaults + user-global only).
+pub fn global_config() -> AuthzConfig {
+    let guard = GLOBAL_CONFIG.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(cfg) = guard.as_ref() {
+        return cfg.clone();
+    }
+    drop(guard);
+    // Lazy-init with defaults
+    init(None);
+    GLOBAL_CONFIG
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .as_ref()
+        .cloned()
+        .unwrap_or_else(config::defaults)
+}
+
+/// Initialize (or reload) the process-wide config from the given repo root.
+///
+/// Typically called once at startup from `main()` with the current working dir.
+pub fn init(repo_root: Option<&std::path::Path>) {
+    let cfg = config::load(repo_root);
+    let mut guard = GLOBAL_CONFIG.lock().unwrap_or_else(|e| e.into_inner());
+    *guard = Some(cfg);
+}

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -213,6 +213,22 @@ pub fn screenshot() -> Result<Vec<u8>, String> {
     })
 }
 
+/// Capture current tab as JPEG with the given quality (1-100).
+/// Prefer over `screenshot()` when streaming (e.g. Monitor view) — JPEG 80
+/// compresses Flutter / typical UI screens to ~50 KB vs 500 KB for PNG.
+pub fn screenshot_jpeg(quality: u8) -> Result<Vec<u8>, String> {
+    with_tab(|tab| {
+        let q = quality.clamp(1, 100) as u32;
+        tab.capture_screenshot(
+            CaptureScreenshotFormatOption::Jpeg,
+            Some(q),
+            None,
+            true,
+        )
+        .map_err(|e| format!("screenshot_jpeg: {e}"))
+    })
+}
+
 #[allow(dead_code)]
 pub fn navigate_and_screenshot(url: &str) -> Result<Vec<u8>, String> {
     ensure_open_reusing()?;
@@ -564,8 +580,25 @@ pub fn close_tab(index: usize) -> Result<(), String> {
 ///
 /// Use case: OAuth flows that pop a Google/Telegram window — Sirin
 /// previously only saw the original tab and missed the popup entirely.
-pub fn wait_for_new_tab(baseline_count: usize, timeout_ms: u64) -> Result<usize, String> {
+pub fn wait_for_new_tab(baseline_count: Option<usize>, timeout_ms: u64) -> Result<usize, String> {
     let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+
+    // Measure baseline from the SAME source the loop polls (headless_chrome's
+    // Browser.get_tabs()), not from our singleton's cached `inner.tabs` —
+    // otherwise we may compare apples to oranges and immediately succeed.
+    // We also `register_missing_tabs` first so the baseline reflects all
+    // tabs Chrome currently knows about (about:blank, etc).
+    let baseline = match baseline_count {
+        Some(n) => n,
+        None => {
+            let guard = global().lock().unwrap_or_else(|e| e.into_inner());
+            let inner = guard.as_ref().ok_or("browser not open")?;
+            inner.browser.register_missing_tabs();
+            let tabs_arc = inner.browser.get_tabs().clone();
+            let locked = tabs_arc.lock().unwrap_or_else(|e| e.into_inner());
+            locked.len()
+        }
+    };
 
     loop {
         // Force the underlying Browser to discover tabs created via window.open
@@ -586,7 +619,7 @@ pub fn wait_for_new_tab(baseline_count: usize, timeout_ms: u64) -> Result<usize,
             locked.iter().cloned().collect()
         };
 
-        if browser_tabs.len() > baseline_count {
+        if browser_tabs.len() > baseline {
             // Find the new tab(s) and adopt them into our singleton.
             let mut guard = global().lock().unwrap_or_else(|e| e.into_inner());
             let inner = guard.as_mut().ok_or("browser not open")?;
@@ -1239,6 +1272,17 @@ mod tests {
 
         close();
         println!("✓ browser_tier2_coords: all steps passed");
+    }
+
+    #[test]
+    #[ignore] // needs Chrome; E2E test
+    fn test_screenshot_jpeg_smoke() {
+        navigate_and_screenshot("https://example.com").unwrap();
+        let jpg = screenshot_jpeg(80).expect("jpeg");
+        // JPEG magic: FF D8 FF
+        assert_eq!(&jpg[..3], &[0xFF, 0xD8, 0xFF], "not a JPEG");
+        assert!(jpg.len() > 100, "too small");
+        assert!(jpg.len() < 500_000, "unexpectedly large (quality too high?)");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 mod adk;
 #[allow(dead_code)] mod agent_config;
+#[allow(dead_code)] mod authz;
 pub mod error;
 mod platform;
 #[allow(dead_code)] mod browser;
@@ -24,6 +25,7 @@ mod log_buffer;
 #[allow(dead_code)] mod researcher;
 #[allow(dead_code)] mod mcp_client;
 mod mcp_server;
+#[allow(dead_code)] pub mod monitor;
 mod rhai_engine;
 mod rpc_server;
 #[allow(dead_code)] mod teams;

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -751,8 +751,8 @@ async fn call_browser_exec(args: Value) -> Result<Value, String> {
             // ── Multi-tab / popup ───────────────────────────────────
             "wait_new_tab" => {
                 let to_ms = timeout.unwrap_or(10000);
-                let baseline = browser::list_tabs().map(|v| v.len()).unwrap_or(1);
-                let idx = browser::wait_for_new_tab(baseline, to_ms)?;
+                // baseline=None → fn measures from same source as its loop
+                let idx = browser::wait_for_new_tab(None, to_ms)?;
                 Ok(json!({ "status": "new tab opened", "active_tab": idx }))
             }
             // ── Network ─────────────────────────────────────────────

--- a/src/monitor/events.rs
+++ b/src/monitor/events.rs
@@ -1,0 +1,376 @@
+//! Monitor event types — ServerEvent and ClientCommand.
+//!
+//! `ServerEvent` is the stream emitted by Sirin toward any observer
+//! (egui UI, WebSocket clients, NDJSON trace file).
+//!
+//! `ClientCommand` is the inverse: messages from an observer back to
+//! the Sirin control plane (pause, resume, authz decisions, etc.).
+//!
+//! Both enums use internally-tagged serde (`#[serde(tag = "type")]`)
+//! to match the TypeScript schema in DESIGN_MONITOR §5 exactly.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+// ── ServerEvent ───────────────────────────────────────────────────────────────
+
+/// Every event that Sirin can emit to observers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ServerEvent {
+    /// Sent once on connection/init — identifies the Sirin version and
+    /// currently connected client IDs.
+    Hello {
+        ts: DateTime<Utc>,
+        sirin_version: String,
+        clients: Vec<String>,
+    },
+
+    /// An action is about to execute.
+    ActionStart {
+        /// Unique action invocation ID (UUID or monotonic counter as string).
+        id: String,
+        ts: DateTime<Utc>,
+        /// MCP client identifier that requested the action.
+        client: String,
+        /// Action name (e.g. `"ax_click"`, `"navigate"`).
+        action: String,
+        /// Full args as a JSON value.
+        args: serde_json::Value,
+    },
+
+    /// An action finished successfully.
+    ActionDone {
+        id: String,
+        ts: DateTime<Utc>,
+        result: serde_json::Value,
+        duration_ms: u64,
+    },
+
+    /// An action finished with an error.
+    ActionError {
+        id: String,
+        ts: DateTime<Utc>,
+        error: String,
+    },
+
+    /// A human authorisation is required before proceeding.
+    AuthzAsk {
+        request_id: String,
+        ts: DateTime<Utc>,
+        client: String,
+        action: String,
+        args: serde_json::Value,
+        url: String,
+        timeout_ms: u64,
+        learn: bool,
+    },
+
+    /// The outstanding authz ask was resolved (allowed or denied).
+    AuthzResolved {
+        request_id: String,
+        ts: DateTime<Utc>,
+        decision: String,
+    },
+
+    /// A browser screenshot frame (JPEG, base64-encoded).
+    Screenshot {
+        ts: DateTime<Utc>,
+        /// Base64-encoded JPEG bytes.
+        jpeg_base64: String,
+    },
+
+    /// The browser navigated to a new URL.
+    UrlChange {
+        ts: DateTime<Utc>,
+        url: String,
+    },
+
+    /// A browser console log entry.
+    Console {
+        ts: DateTime<Utc>,
+        /// Log level: `"log"`, `"warn"`, `"error"`, `"info"`, `"debug"`.
+        level: String,
+        text: String,
+    },
+
+    /// A network request/response pair captured by CDP.
+    Network {
+        ts: DateTime<Utc>,
+        url: String,
+        method: String,
+        status: u16,
+        size: u64,
+        req_body_preview: Option<String>,
+        res_body_preview: Option<String>,
+    },
+
+    /// Snapshot of the current control state (pause/step/abort flags).
+    State {
+        ts: DateTime<Utc>,
+        paused: bool,
+        step: bool,
+        aborted: bool,
+        view_active: bool,
+    },
+
+    /// Sent when the Sirin session ends or the WS connection is closing.
+    Goodbye {
+        ts: DateTime<Utc>,
+    },
+}
+
+impl ServerEvent {
+    /// Convenience: return the timestamp embedded in any variant.
+    pub fn ts(&self) -> DateTime<Utc> {
+        match self {
+            ServerEvent::Hello { ts, .. } => *ts,
+            ServerEvent::ActionStart { ts, .. } => *ts,
+            ServerEvent::ActionDone { ts, .. } => *ts,
+            ServerEvent::ActionError { ts, .. } => *ts,
+            ServerEvent::AuthzAsk { ts, .. } => *ts,
+            ServerEvent::AuthzResolved { ts, .. } => *ts,
+            ServerEvent::Screenshot { ts, .. } => *ts,
+            ServerEvent::UrlChange { ts, .. } => *ts,
+            ServerEvent::Console { ts, .. } => *ts,
+            ServerEvent::Network { ts, .. } => *ts,
+            ServerEvent::State { ts, .. } => *ts,
+            ServerEvent::Goodbye { ts } => *ts,
+        }
+    }
+}
+
+// ── ClientCommand ─────────────────────────────────────────────────────────────
+
+/// Commands that an observer can send back to Sirin.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClientCommand {
+    /// Resolve a pending authz ask.
+    AuthzResponse {
+        request_id: String,
+        decision: AuthzDecision,
+    },
+    /// Pause action execution (in-flight action finishes; next is blocked).
+    Pause {},
+    /// Resume from a paused state.
+    Resume {},
+    /// Execute the next single action, then auto-pause again.
+    Step {},
+    /// Immediately reject all subsequent actions for this session.
+    Abort {},
+    /// Subscribe/unsubscribe from specific event channels (WS only).
+    Subscribe {
+        channels: Vec<SubscribeChannel>,
+    },
+}
+
+/// The set of decisions available when resolving an authz ask.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthzDecision {
+    AllowOnce,
+    AllowAlwaysUrl,
+    AllowAlwaysAction,
+    Deny,
+    DenyBlock,
+}
+
+/// Named event channels used by the `Subscribe` command.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubscribeChannel {
+    Screenshot,
+    Action,
+    Network,
+    Console,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use serde_json::{from_str, to_string};
+
+    fn now() -> DateTime<Utc> {
+        Utc::now()
+    }
+
+    /// Round-trip helper: serialize → deserialize → serialize again and
+    /// compare the two JSON strings.
+    fn round_trip<T: Serialize + for<'de> Deserialize<'de> + std::fmt::Debug>(v: &T) {
+        let json = to_string(v).expect("serialize failed");
+        let back: T = from_str(&json).expect("deserialize failed");
+        let json2 = to_string(&back).expect("re-serialize failed");
+        assert_eq!(json, json2, "round-trip mismatch for {:?}", v);
+    }
+
+    #[test]
+    fn hello_round_trip() {
+        round_trip(&ServerEvent::Hello {
+            ts: now(),
+            sirin_version: "0.1.0".into(),
+            clients: vec!["claude-desktop".into()],
+        });
+    }
+
+    #[test]
+    fn action_start_round_trip() {
+        round_trip(&ServerEvent::ActionStart {
+            id: "abc-123".into(),
+            ts: now(),
+            client: "claude-code".into(),
+            action: "ax_click".into(),
+            args: serde_json::json!({ "backend_id": 42 }),
+        });
+    }
+
+    #[test]
+    fn action_done_round_trip() {
+        round_trip(&ServerEvent::ActionDone {
+            id: "abc-123".into(),
+            ts: now(),
+            result: serde_json::json!({ "status": "ok" }),
+            duration_ms: 38,
+        });
+    }
+
+    #[test]
+    fn action_error_round_trip() {
+        round_trip(&ServerEvent::ActionError {
+            id: "abc-123".into(),
+            ts: now(),
+            error: "element not found".into(),
+        });
+    }
+
+    #[test]
+    fn authz_ask_round_trip() {
+        round_trip(&ServerEvent::AuthzAsk {
+            request_id: "req-1".into(),
+            ts: now(),
+            client: "claude-desktop".into(),
+            action: "navigate".into(),
+            args: serde_json::json!({ "url": "https://example.com" }),
+            url: "https://example.com".into(),
+            timeout_ms: 30_000,
+            learn: true,
+        });
+    }
+
+    #[test]
+    fn authz_resolved_round_trip() {
+        round_trip(&ServerEvent::AuthzResolved {
+            request_id: "req-1".into(),
+            ts: now(),
+            decision: "allow_once".into(),
+        });
+    }
+
+    #[test]
+    fn screenshot_round_trip() {
+        round_trip(&ServerEvent::Screenshot {
+            ts: now(),
+            jpeg_base64: "AAAA".into(),
+        });
+    }
+
+    #[test]
+    fn url_change_round_trip() {
+        round_trip(&ServerEvent::UrlChange {
+            ts: now(),
+            url: "https://app.example.com/wallet".into(),
+        });
+    }
+
+    #[test]
+    fn console_round_trip() {
+        round_trip(&ServerEvent::Console {
+            ts: now(),
+            level: "error".into(),
+            text: "Uncaught TypeError: null is not an object".into(),
+        });
+    }
+
+    #[test]
+    fn network_round_trip() {
+        round_trip(&ServerEvent::Network {
+            ts: now(),
+            url: "https://api.example.com/v1/users".into(),
+            method: "POST".into(),
+            status: 200,
+            size: 1024,
+            req_body_preview: Some(r#"{"user":"alice"}"#.into()),
+            res_body_preview: None,
+        });
+    }
+
+    #[test]
+    fn state_round_trip() {
+        round_trip(&ServerEvent::State {
+            ts: now(),
+            paused: false,
+            step: false,
+            aborted: false,
+            view_active: true,
+        });
+    }
+
+    #[test]
+    fn goodbye_round_trip() {
+        round_trip(&ServerEvent::Goodbye { ts: now() });
+    }
+
+    // ── ClientCommand round-trips ────────────────────────────────────────────
+
+    #[test]
+    fn authz_response_round_trip() {
+        round_trip(&ClientCommand::AuthzResponse {
+            request_id: "req-1".into(),
+            decision: AuthzDecision::AllowOnce,
+        });
+    }
+
+    #[test]
+    fn pause_round_trip() {
+        round_trip(&ClientCommand::Pause {});
+    }
+
+    #[test]
+    fn resume_round_trip() {
+        round_trip(&ClientCommand::Resume {});
+    }
+
+    #[test]
+    fn step_round_trip() {
+        round_trip(&ClientCommand::Step {});
+    }
+
+    #[test]
+    fn abort_round_trip() {
+        round_trip(&ClientCommand::Abort {});
+    }
+
+    #[test]
+    fn subscribe_round_trip() {
+        round_trip(&ClientCommand::Subscribe {
+            channels: vec![SubscribeChannel::Screenshot, SubscribeChannel::Action],
+        });
+    }
+
+    #[test]
+    fn type_tag_present_in_json() {
+        // Verify that the `type` discriminant is present and lowercase_snake
+        let json = to_string(&ServerEvent::UrlChange {
+            ts: now(),
+            url: "https://x.com".into(),
+        })
+        .unwrap();
+        assert!(json.contains(r#""type":"url_change""#), "missing type tag: {json}");
+
+        let json = to_string(&ClientCommand::Pause {}).unwrap();
+        assert!(json.contains(r#""type":"pause""#), "missing type tag: {json}");
+    }
+}

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -1,0 +1,314 @@
+//! Live GUI Monitor — core module.
+//!
+//! ## Quick start
+//!
+//! ```rust,ignore
+//! // In main.rs, after creating the trace path:
+//! monitor::init(MonitorConfig {
+//!     trace_dir: PathBuf::from(".sirin"),
+//!     trace_size_limit: None,   // use default 100 MB
+//! });
+//!
+//! // Anywhere an action starts:
+//! monitor::emit_action_start("claude-desktop", "axid-1", "ax_click",
+//!                            serde_json::json!({"backend_id": 42})).await;
+//! ```
+//!
+//! All emit helpers are **no-ops** if `init` was never called (they silently
+//! return).  This makes the monitor fully optional — callers need not guard
+//! against an uninitialised state.
+//!
+//! ## Thread / task safety
+//! The global `Arc<MonitorState>` is cheaply cloneable.  Emit helpers acquire
+//! the internal `RwLock` only long enough to push one event.
+
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
+
+use chrono::Utc;
+use serde_json::Value;
+
+pub mod events;
+pub mod state;
+pub mod trace_writer;
+
+pub use events::{AuthzDecision, ClientCommand, ServerEvent, SubscribeChannel};
+pub use state::MonitorState;
+pub use trace_writer::TraceWriter;
+
+// ── Global singleton ──────────────────────────────────────────────────────────
+
+static MONITOR: OnceLock<Arc<MonitorState>> = OnceLock::new();
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+/// Configuration passed to [`init`].
+pub struct MonitorConfig {
+    /// Directory where trace NDJSON files are written.
+    /// A file named `trace-<ISO8601>.ndjson` is created inside this dir.
+    pub trace_dir: PathBuf,
+
+    /// Rotation threshold in bytes.  `None` → use the 100 MiB default.
+    pub trace_size_limit: Option<u64>,
+}
+
+// ── Initialisation ────────────────────────────────────────────────────────────
+
+/// Initialise the global monitor singleton.
+///
+/// Call once at startup (from `main.rs`).  Subsequent calls are silently
+/// ignored — `OnceLock` guarantees single initialisation.
+///
+/// Returns the shared `Arc<MonitorState>` for callers that want to hold a
+/// handle without going through the `state()` accessor every time.
+pub fn init(config: MonitorConfig) -> Arc<MonitorState> {
+    let state = MONITOR.get_or_init(|| Arc::new(MonitorState::new()));
+    let state_clone = Arc::clone(state);
+
+    // Spawn trace-writer task.  We do this in a blocking thread because
+    // TraceWriter uses synchronous file I/O.  The task receives events via
+    // a channel and writes them serially — no lock contention on the hot path.
+    let trace_dir = config.trace_dir.clone();
+    let size_limit = config.trace_size_limit.unwrap_or(trace_writer::DEFAULT_SIZE_LIMIT);
+
+    std::thread::Builder::new()
+        .name("monitor-trace-writer".into())
+        .spawn(move || {
+            run_trace_writer(trace_dir, size_limit, state_clone);
+        })
+        .unwrap_or_else(|e| {
+            eprintln!("[monitor] failed to spawn trace-writer thread: {e}");
+            // Return a dummy JoinHandle-like value — the spawn itself returned Err,
+            // so we have nothing to store.  This path is extremely unlikely.
+            panic!("thread spawn failed");
+        });
+
+    Arc::clone(state)
+}
+
+/// Return the global `MonitorState`, or `None` if `init` was never called.
+pub fn state() -> Option<Arc<MonitorState>> {
+    MONITOR.get().map(Arc::clone)
+}
+
+// ── Trace-writer thread ───────────────────────────────────────────────────────
+
+/// Blocking loop: poll the MonitorState event queue every 50 ms and flush
+/// new events to the trace file.
+///
+/// This approach avoids a separate channel and keeps state as the single
+/// source of truth.  The writer remembers its write cursor (last event index
+/// tracked via event count) and flushes only the delta each tick.
+fn run_trace_writer(trace_dir: PathBuf, size_limit: u64, state: Arc<MonitorState>) {
+    // Build the trace file path: <trace_dir>/trace-<ISO8601>.ndjson
+    let ts = Utc::now().format("%Y%m%dT%H%M%SZ");
+    let filename = format!("trace-{ts}.ndjson");
+    let path = trace_dir.join(filename);
+
+    let mut writer = match TraceWriter::open_with_limit(&path, size_limit) {
+        Ok(w) => w,
+        Err(e) => {
+            eprintln!("[monitor] trace_writer: could not open {path:?}: {e}");
+            return;
+        }
+    };
+
+    let mut last_count = 0usize;
+
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let events = state.events_snapshot();
+        let new_events = if events.len() > last_count {
+            events[last_count..].to_vec()
+        } else if events.len() < last_count {
+            // State was cleared — reset cursor, don't re-write old events
+            last_count = events.len();
+            continue;
+        } else {
+            continue;
+        };
+
+        for ev in &new_events {
+            if let Err(e) = writer.write_event(ev) {
+                eprintln!("[monitor] trace_writer: write error: {e}");
+            }
+        }
+
+        last_count += new_events.len();
+    }
+}
+
+// ── Emit helpers ──────────────────────────────────────────────────────────────
+
+/// Push a `Hello` event and register `client_id` as connected.
+pub async fn emit_hello(sirin_version: impl Into<String>) {
+    let Some(st) = state() else { return };
+    let clients: Vec<String> = st.clients_snapshot().into_iter().collect();
+    st.push_event(ServerEvent::Hello {
+        ts: Utc::now(),
+        sirin_version: sirin_version.into(),
+        clients,
+    });
+}
+
+/// Push an `ActionStart` event.
+pub async fn emit_action_start(
+    client: impl Into<String>,
+    id: impl Into<String>,
+    action: impl Into<String>,
+    args: Value,
+) {
+    let Some(st) = state() else { return };
+    st.push_event(ServerEvent::ActionStart {
+        id: id.into(),
+        ts: Utc::now(),
+        client: client.into(),
+        action: action.into(),
+        args,
+    });
+}
+
+/// Push an `ActionDone` event.
+pub async fn emit_action_done(id: impl Into<String>, result: Value, duration_ms: u64) {
+    let Some(st) = state() else { return };
+    st.push_event(ServerEvent::ActionDone {
+        id: id.into(),
+        ts: Utc::now(),
+        result,
+        duration_ms,
+    });
+}
+
+/// Push an `ActionError` event.
+pub async fn emit_action_error(id: impl Into<String>, error: impl Into<String>) {
+    let Some(st) = state() else { return };
+    st.push_event(ServerEvent::ActionError {
+        id: id.into(),
+        ts: Utc::now(),
+        error: error.into(),
+    });
+}
+
+/// Push an `AuthzAsk` event.
+#[allow(clippy::too_many_arguments)]
+pub async fn emit_authz_ask(
+    request_id: impl Into<String>,
+    client: impl Into<String>,
+    action: impl Into<String>,
+    args: Value,
+    url: impl Into<String>,
+    timeout_ms: u64,
+    learn: bool,
+) {
+    let Some(st) = state() else { return };
+    st.push_event(ServerEvent::AuthzAsk {
+        request_id: request_id.into(),
+        ts: Utc::now(),
+        client: client.into(),
+        action: action.into(),
+        args,
+        url: url.into(),
+        timeout_ms,
+        learn,
+    });
+}
+
+/// Push an `AuthzResolved` event.
+pub async fn emit_authz_resolved(request_id: impl Into<String>, decision: impl Into<String>) {
+    let Some(st) = state() else { return };
+    st.push_event(ServerEvent::AuthzResolved {
+        request_id: request_id.into(),
+        ts: Utc::now(),
+        decision: decision.into(),
+    });
+}
+
+/// Push a `UrlChange` event.
+pub async fn emit_url_change(url: impl Into<String>) {
+    let Some(st) = state() else { return };
+    st.push_event(ServerEvent::UrlChange {
+        ts: Utc::now(),
+        url: url.into(),
+    });
+}
+
+/// Push a `Console` event.
+pub async fn emit_console(level: impl Into<String>, text: impl Into<String>) {
+    let Some(st) = state() else { return };
+    st.push_event(ServerEvent::Console {
+        ts: Utc::now(),
+        level: level.into(),
+        text: text.into(),
+    });
+}
+
+/// Push a `Network` event.
+#[allow(clippy::too_many_arguments)]
+pub async fn emit_network(
+    url: impl Into<String>,
+    method: impl Into<String>,
+    status: u16,
+    size: u64,
+    req_body_preview: Option<String>,
+    res_body_preview: Option<String>,
+) {
+    let Some(st) = state() else { return };
+    st.push_event(ServerEvent::Network {
+        ts: Utc::now(),
+        url: url.into(),
+        method: method.into(),
+        status,
+        size,
+        req_body_preview,
+        res_body_preview,
+    });
+}
+
+/// Push a `State` snapshot event reflecting current control flags.
+pub async fn emit_state(paused: bool, step: bool, aborted: bool) {
+    let Some(st) = state() else { return };
+    let view_active = st.view_active();
+    st.push_event(ServerEvent::State {
+        ts: Utc::now(),
+        paused,
+        step,
+        aborted,
+        view_active,
+    });
+}
+
+/// Push a `Goodbye` event (called on session teardown).
+pub async fn emit_goodbye() {
+    let Some(st) = state() else { return };
+    st.push_event(ServerEvent::Goodbye { ts: Utc::now() });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helpers that call `state()` when monitor is not initialised must be
+    /// no-ops — they must not panic.
+    #[tokio::test]
+    async fn emit_without_init_is_noop() {
+        // These should all return without panicking even though `init` was
+        // never called in this test binary's module-level init.
+        // (MONITOR may already be set from another test; that's fine — the
+        // calls will push to a real queue which is harmless.)
+        emit_url_change("https://noop.test").await;
+        emit_console("info", "hello").await;
+        emit_action_error("id-0", "oops").await;
+        emit_goodbye().await;
+    }
+
+    #[test]
+    fn state_returns_none_before_init_in_new_process() {
+        // We can't truly reset OnceLock in a running test binary, so we just
+        // verify that `state()` returns *something* (Some or None) without
+        // panicking regardless of init order.
+        let _ = state();
+    }
+}

--- a/src/monitor/state.rs
+++ b/src/monitor/state.rs
@@ -1,0 +1,297 @@
+//! Shared monitor state: event queue, screenshot buffer, client registry.
+//!
+//! `MonitorState` is an `Arc<RwLock<MonitorStateInner>>` newtype. All writer
+//! methods live on `MonitorState` (take `&self`) and acquire the write-lock
+//! internally, so callers never need to hold the lock directly.
+//!
+//! ## Eviction policy
+//! - Events: retain the most recent 1 000.
+//! - Screenshots: retain the most recent 50.
+//!
+//! This caps memory at roughly 5 MB per the DESIGN_MONITOR §8 budget.
+
+use std::collections::{HashSet, VecDeque};
+use std::sync::{Arc, RwLock};
+
+use chrono::{DateTime, Utc};
+
+use super::events::ServerEvent;
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+pub const MAX_EVENTS: usize = 1_000;
+pub const MAX_SCREENSHOTS: usize = 50;
+
+// ── Inner state ───────────────────────────────────────────────────────────────
+
+/// The mutable interior of `MonitorState`.
+pub struct MonitorStateInner {
+    /// Circular event log — newest at the back.
+    pub events: VecDeque<ServerEvent>,
+
+    /// Recent screenshots `(captured_at, jpeg_bytes)` — newest at the back.
+    pub screenshots: VecDeque<(DateTime<Utc>, Vec<u8>)>,
+
+    /// True while the Monitor egui view is open and visible.
+    pub view_active: bool,
+
+    /// True when the screenshot pump should skip taking frames
+    /// (user hit "Pause stream" in the screenshot pane).
+    pub paused_stream: bool,
+
+    /// Set of currently-connected client IDs.
+    pub clients: HashSet<String>,
+}
+
+impl MonitorStateInner {
+    fn new() -> Self {
+        Self {
+            events: VecDeque::with_capacity(MAX_EVENTS),
+            screenshots: VecDeque::with_capacity(MAX_SCREENSHOTS),
+            view_active: false,
+            paused_stream: false,
+            clients: HashSet::new(),
+        }
+    }
+}
+
+// ── Public newtype ────────────────────────────────────────────────────────────
+
+/// Thread-safe, cheaply-cloneable monitor state.
+#[derive(Clone)]
+pub struct MonitorState(Arc<RwLock<MonitorStateInner>>);
+
+impl MonitorState {
+    /// Create a fresh, empty state.
+    pub fn new() -> Self {
+        Self(Arc::new(RwLock::new(MonitorStateInner::new())))
+    }
+
+    // ── Read access ──────────────────────────────────────────────────────────
+
+    /// Snapshot all current events (cloned).
+    pub fn events_snapshot(&self) -> Vec<ServerEvent> {
+        let inner = self.0.read().unwrap_or_else(|e| e.into_inner());
+        inner.events.iter().cloned().collect()
+    }
+
+    /// Latest screenshot, if any.
+    pub fn latest_screenshot(&self) -> Option<(DateTime<Utc>, Vec<u8>)> {
+        let inner = self.0.read().unwrap_or_else(|e| e.into_inner());
+        inner.screenshots.back().cloned()
+    }
+
+    pub fn view_active(&self) -> bool {
+        self.0.read().unwrap_or_else(|e| e.into_inner()).view_active
+    }
+
+    pub fn paused_stream(&self) -> bool {
+        self.0.read().unwrap_or_else(|e| e.into_inner()).paused_stream
+    }
+
+    pub fn clients_snapshot(&self) -> HashSet<String> {
+        self.0.read().unwrap_or_else(|e| e.into_inner()).clients.clone()
+    }
+
+    // ── Write access ─────────────────────────────────────────────────────────
+
+    /// Append an event, evicting the oldest when the queue is full.
+    pub fn push_event(&self, event: ServerEvent) {
+        let mut inner = self.0.write().unwrap_or_else(|e| e.into_inner());
+        if inner.events.len() >= MAX_EVENTS {
+            inner.events.pop_front();
+        }
+        inner.events.push_back(event);
+    }
+
+    /// Append a screenshot frame, evicting the oldest when the buffer is full.
+    pub fn push_screenshot(&self, ts: DateTime<Utc>, jpeg_bytes: Vec<u8>) {
+        let mut inner = self.0.write().unwrap_or_else(|e| e.into_inner());
+        if inner.screenshots.len() >= MAX_SCREENSHOTS {
+            inner.screenshots.pop_front();
+        }
+        inner.screenshots.push_back((ts, jpeg_bytes));
+    }
+
+    /// Record whether the Monitor view is currently open.
+    pub fn set_view_active(&self, active: bool) {
+        self.0.write().unwrap_or_else(|e| e.into_inner()).view_active = active;
+    }
+
+    /// Pause or resume the screenshot stream (does not affect action gating).
+    pub fn set_paused_stream(&self, paused: bool) {
+        self.0.write().unwrap_or_else(|e| e.into_inner()).paused_stream = paused;
+    }
+
+    /// Register or unregister a client ID.
+    pub fn mark_client(&self, client_id: &str, connected: bool) {
+        let mut inner = self.0.write().unwrap_or_else(|e| e.into_inner());
+        if connected {
+            inner.clients.insert(client_id.to_owned());
+        } else {
+            inner.clients.remove(client_id);
+        }
+    }
+
+    /// Clear the event queue and screenshot buffer (e.g. user pressed "Clear").
+    pub fn clear(&self) {
+        let mut inner = self.0.write().unwrap_or_else(|e| e.into_inner());
+        inner.events.clear();
+        inner.screenshots.clear();
+    }
+
+    /// Number of events currently held.
+    pub fn event_count(&self) -> usize {
+        self.0.read().unwrap_or_else(|e| e.into_inner()).events.len()
+    }
+
+    /// Number of screenshots currently held.
+    pub fn screenshot_count(&self) -> usize {
+        self.0.read().unwrap_or_else(|e| e.into_inner()).screenshots.len()
+    }
+}
+
+impl Default for MonitorState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn make_event(n: u32) -> ServerEvent {
+        ServerEvent::UrlChange {
+            ts: Utc::now(),
+            url: format!("https://example.com/{n}"),
+        }
+    }
+
+    // ── Event queue eviction ─────────────────────────────────────────────────
+
+    #[test]
+    fn event_queue_evicts_oldest_when_full() {
+        let state = MonitorState::new();
+
+        // Push MAX_EVENTS events — URLs /0 … /999
+        for i in 0..MAX_EVENTS as u32 {
+            state.push_event(make_event(i));
+        }
+        assert_eq!(state.event_count(), MAX_EVENTS);
+
+        // Push one more — should drop URL /0, keep /1 … /1000
+        state.push_event(make_event(MAX_EVENTS as u32));
+        assert_eq!(state.event_count(), MAX_EVENTS, "queue must stay at capacity");
+
+        let events = state.events_snapshot();
+        let first_url = match &events[0] {
+            ServerEvent::UrlChange { url, .. } => url.clone(),
+            _ => panic!("unexpected variant"),
+        };
+        assert_eq!(
+            first_url, "https://example.com/1",
+            "oldest event was not evicted"
+        );
+
+        let last_url = match events.last().unwrap() {
+            ServerEvent::UrlChange { url, .. } => url.clone(),
+            _ => panic!("unexpected variant"),
+        };
+        assert_eq!(
+            last_url,
+            format!("https://example.com/{}", MAX_EVENTS),
+            "newest event is wrong"
+        );
+    }
+
+    #[test]
+    fn event_queue_below_capacity_no_eviction() {
+        let state = MonitorState::new();
+        for i in 0..10u32 {
+            state.push_event(make_event(i));
+        }
+        assert_eq!(state.event_count(), 10);
+    }
+
+    // ── Screenshot queue eviction ────────────────────────────────────────────
+
+    #[test]
+    fn screenshot_queue_evicts_oldest_when_full() {
+        let state = MonitorState::new();
+
+        for i in 0..MAX_SCREENSHOTS {
+            state.push_screenshot(Utc::now(), vec![i as u8]);
+        }
+        assert_eq!(state.screenshot_count(), MAX_SCREENSHOTS);
+
+        // Push one more
+        state.push_screenshot(Utc::now(), vec![0xFF]);
+        assert_eq!(
+            state.screenshot_count(),
+            MAX_SCREENSHOTS,
+            "screenshot queue must stay at capacity"
+        );
+
+        // The latest frame should be our 0xFF sentinel
+        let (_, latest) = state.latest_screenshot().unwrap();
+        assert_eq!(latest, vec![0xFF], "latest screenshot is wrong after eviction");
+    }
+
+    #[test]
+    fn screenshot_queue_below_capacity_no_eviction() {
+        let state = MonitorState::new();
+        state.push_screenshot(Utc::now(), vec![1, 2, 3]);
+        state.push_screenshot(Utc::now(), vec![4, 5, 6]);
+        assert_eq!(state.screenshot_count(), 2);
+    }
+
+    // ── Flag mutations ───────────────────────────────────────────────────────
+
+    #[test]
+    fn view_active_toggle() {
+        let state = MonitorState::new();
+        assert!(!state.view_active());
+        state.set_view_active(true);
+        assert!(state.view_active());
+        state.set_view_active(false);
+        assert!(!state.view_active());
+    }
+
+    #[test]
+    fn paused_stream_toggle() {
+        let state = MonitorState::new();
+        assert!(!state.paused_stream());
+        state.set_paused_stream(true);
+        assert!(state.paused_stream());
+    }
+
+    // ── Client registry ──────────────────────────────────────────────────────
+
+    #[test]
+    fn client_connect_disconnect() {
+        let state = MonitorState::new();
+        state.mark_client("claude-desktop", true);
+        state.mark_client("claude-code", true);
+        assert_eq!(state.clients_snapshot().len(), 2);
+
+        state.mark_client("claude-desktop", false);
+        assert_eq!(state.clients_snapshot().len(), 1);
+        assert!(state.clients_snapshot().contains("claude-code"));
+    }
+
+    // ── Clear ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn clear_resets_queues() {
+        let state = MonitorState::new();
+        state.push_event(make_event(0));
+        state.push_screenshot(Utc::now(), vec![1]);
+        state.clear();
+        assert_eq!(state.event_count(), 0);
+        assert_eq!(state.screenshot_count(), 0);
+    }
+}

--- a/src/monitor/trace_writer.rs
+++ b/src/monitor/trace_writer.rs
@@ -1,0 +1,314 @@
+//! NDJSON trace writer with file rotation.
+//!
+//! Each Sirin session creates one `TraceWriter`.  Every `ServerEvent` is
+//! serialized as a single JSON line and appended to the file.
+//!
+//! ## Rotation
+//! When the current file exceeds `size_limit` bytes the writer rotates:
+//!
+//! ```text
+//! trace-<ts>.ndjson      ← current (reset to empty)
+//! trace-<ts>.ndjson.1    ← was current
+//! trace-<ts>.ndjson.2    ← was .1
+//! …
+//! trace-<ts>.ndjson.20   ← oldest retained
+//! trace-<ts>.ndjson.21+  ← deleted
+//! ```
+//!
+//! The default limit is 100 MiB; tests pass a smaller value.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use super::events::ServerEvent;
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Default rotation threshold: 100 MiB.
+pub const DEFAULT_SIZE_LIMIT: u64 = 100 * 1024 * 1024;
+
+/// Maximum number of rotated files to keep alongside the live file.
+pub const MAX_ROTATIONS: u32 = 20;
+
+// ── TraceWriter ───────────────────────────────────────────────────────────────
+
+/// Appends `ServerEvent` lines to an NDJSON file with rotation.
+pub struct TraceWriter {
+    /// Path to the currently-open file (e.g. `…/.sirin/trace-<ts>.ndjson`).
+    path: PathBuf,
+    /// Open file handle (append mode).
+    file: File,
+    /// How many bytes have been written to the current file.
+    bytes_written: u64,
+    /// Rotate when `bytes_written` exceeds this threshold.
+    size_limit: u64,
+}
+
+impl TraceWriter {
+    /// Open (or create) the trace file at `path`.
+    ///
+    /// The parent directory is created if it does not exist.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, String> {
+        Self::open_with_limit(path, DEFAULT_SIZE_LIMIT)
+    }
+
+    /// Same as `open`, but with a custom `size_limit` (useful for testing).
+    pub fn open_with_limit(path: impl AsRef<Path>, size_limit: u64) -> Result<Self, String> {
+        let path = path.as_ref().to_path_buf();
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("trace_writer: mkdir {:?}: {e}", parent))?;
+        }
+
+        let file = open_append(&path)?;
+        let bytes_written = file
+            .metadata()
+            .map(|m| m.len())
+            .unwrap_or(0);
+
+        Ok(Self { path, file, bytes_written, size_limit })
+    }
+
+    /// Serialize `event` as a JSON line and append it to the trace file.
+    ///
+    /// Rotates the file first if the current size would exceed `size_limit`.
+    pub fn write_event(&mut self, event: &ServerEvent) -> Result<(), String> {
+        let line = serde_json::to_string(event)
+            .map_err(|e| format!("trace_writer: serialize: {e}"))?;
+
+        // Rotate before writing if the new line would push us over the limit.
+        // (We compare against the current size before appending.)
+        let line_bytes = (line.len() + 1) as u64; // +1 for '\n'
+        if self.bytes_written + line_bytes > self.size_limit && self.bytes_written > 0 {
+            self.rotate()?;
+        }
+
+        writeln!(self.file, "{}", line)
+            .map_err(|e| format!("trace_writer: write: {e}"))?;
+        self.file
+            .flush()
+            .map_err(|e| format!("trace_writer: flush: {e}"))?;
+
+        self.bytes_written += line_bytes;
+        Ok(())
+    }
+
+    /// Current byte count of the live file (approximate — updated at each write).
+    pub fn bytes_written(&self) -> u64 {
+        self.bytes_written
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    /// Rotate: shift `.N` → `.N+1` (dropping > MAX_ROTATIONS), rename live →
+    /// `.1`, then re-open the live path as a fresh empty file.
+    fn rotate(&mut self) -> Result<(), String> {
+        // Drop the current file handle so we can rename it.
+        // We re-open at the end.
+        // We can't move `self.file` without a replacement, so close via flush first
+        // (the File will be replaced by re-open below).
+        self.file
+            .flush()
+            .map_err(|e| format!("trace_writer: pre-rotate flush: {e}"))?;
+
+        // Shift existing rotated files:  .20 → deleted, .19 → .20, …, .1 → .2
+        for n in (1..=MAX_ROTATIONS).rev() {
+            let from = rotated_path(&self.path, n);
+            let to = rotated_path(&self.path, n + 1);
+
+            if from.exists() {
+                if n == MAX_ROTATIONS {
+                    // Delete the oldest
+                    fs::remove_file(&from)
+                        .map_err(|e| format!("trace_writer: remove {:?}: {e}", from))?;
+                } else {
+                    fs::rename(&from, &to)
+                        .map_err(|e| format!("trace_writer: rename {:?} → {:?}: {e}", from, to))?;
+                }
+            }
+        }
+
+        // Rename live file to .1
+        let backup = rotated_path(&self.path, 1);
+        fs::rename(&self.path, &backup)
+            .map_err(|e| format!("trace_writer: rename live → .1: {e}"))?;
+
+        // Re-open a fresh live file
+        self.file = open_append(&self.path)?;
+        self.bytes_written = 0;
+        Ok(())
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn open_append(path: &Path) -> Result<File, String> {
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| format!("trace_writer: open {:?}: {e}", path))
+}
+
+fn rotated_path(base: &Path, n: u32) -> PathBuf {
+    let mut s = base.as_os_str().to_os_string();
+    s.push(format!(".{n}"));
+    PathBuf::from(s)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::io::Read as IoRead;
+
+    /// Create a unique temp directory for one test (no external crate needed).
+    fn test_dir(name: &str) -> PathBuf {
+        let base = std::env::temp_dir()
+            .join("sirin_monitor_tests")
+            .join(format!("{}_{}", name, std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .subsec_nanos()));
+        fs::create_dir_all(&base).unwrap();
+        base
+    }
+
+    fn sample_event() -> ServerEvent {
+        ServerEvent::UrlChange {
+            ts: Utc::now(),
+            url: "https://example.com/test".into(),
+        }
+    }
+
+    fn line_count(path: &Path) -> usize {
+        let mut s = String::new();
+        File::open(path).unwrap().read_to_string(&mut s).unwrap();
+        s.lines().filter(|l| !l.is_empty()).count()
+    }
+
+    // ── Basic write ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn writes_ndjson_lines() {
+        let dir = test_dir("writes_ndjson_lines");
+        let path = dir.join("trace.ndjson");
+        let mut w = TraceWriter::open_with_limit(&path, DEFAULT_SIZE_LIMIT).unwrap();
+
+        w.write_event(&sample_event()).unwrap();
+        w.write_event(&sample_event()).unwrap();
+
+        assert_eq!(line_count(&path), 2);
+        assert!(w.bytes_written() > 0);
+    }
+
+    #[test]
+    fn written_lines_are_valid_json() {
+        let dir = test_dir("valid_json");
+        let path = dir.join("trace.ndjson");
+        let mut w = TraceWriter::open_with_limit(&path, DEFAULT_SIZE_LIMIT).unwrap();
+        w.write_event(&sample_event()).unwrap();
+
+        let mut s = String::new();
+        File::open(&path).unwrap().read_to_string(&mut s).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(s.trim()).unwrap();
+        assert_eq!(parsed["type"], "url_change");
+    }
+
+    // ── Small-file, no rotation ───────────────────────────────────────────────
+
+    #[test]
+    fn small_file_does_not_rotate() {
+        let dir = test_dir("no_rotate");
+        let path = dir.join("trace.ndjson");
+        // Very large limit — rotation must NOT trigger
+        let mut w = TraceWriter::open_with_limit(&path, DEFAULT_SIZE_LIMIT).unwrap();
+        w.write_event(&sample_event()).unwrap();
+
+        // No .1 file should exist
+        assert!(
+            !rotated_path(&path, 1).exists(),
+            "rotation must not happen for small file"
+        );
+    }
+
+    // ── Rotation on size overflow ─────────────────────────────────────────────
+
+    #[test]
+    fn rotation_triggers_when_limit_exceeded() {
+        let dir = test_dir("rotation_triggers");
+        let path = dir.join("trace.ndjson");
+        // Limit of 1 byte → every subsequent write triggers rotation
+        let mut w = TraceWriter::open_with_limit(&path, 1).unwrap();
+
+        w.write_event(&sample_event()).unwrap(); // first write — file is empty, goes in
+        w.write_event(&sample_event()).unwrap(); // triggers rotation before writing
+
+        // The live file should have the second line; .1 should have the first
+        assert!(rotated_path(&path, 1).exists(), ".1 must exist after rotation");
+        assert_eq!(line_count(&path), 1, "live file should have 1 line after rotation");
+        assert_eq!(
+            line_count(&rotated_path(&path, 1)),
+            1,
+            ".1 should have 1 line"
+        );
+    }
+
+    #[test]
+    fn rotation_shifts_existing_rotations() {
+        let dir = test_dir("rotation_shifts");
+        let path = dir.join("trace.ndjson");
+        let limit = 1u64; // force rotation on every second write
+        let mut w = TraceWriter::open_with_limit(&path, limit).unwrap();
+
+        // Write 3 events → 2 rotations → files: live, .1, .2
+        for _ in 0..3 {
+            w.write_event(&sample_event()).unwrap();
+        }
+
+        assert!(rotated_path(&path, 1).exists(), ".1 must exist");
+        assert!(rotated_path(&path, 2).exists(), ".2 must exist");
+    }
+
+    // ── MAX_ROTATIONS cap ─────────────────────────────────────────────────────
+
+    #[test]
+    fn rotation_cap_does_not_exceed_max() {
+        let dir = test_dir("rotation_cap");
+        let path = dir.join("trace.ndjson");
+        let limit = 1u64;
+        let mut w = TraceWriter::open_with_limit(&path, limit).unwrap();
+
+        // Write MAX_ROTATIONS + 5 more events to force many rotations.
+        // We need MAX_ROTATIONS + 2 writes: first write fills the file,
+        // each subsequent write triggers one rotation.
+        for _ in 0..(MAX_ROTATIONS + 5) {
+            w.write_event(&sample_event()).unwrap();
+        }
+
+        // No file beyond .MAX_ROTATIONS should exist
+        assert!(
+            !rotated_path(&path, MAX_ROTATIONS + 1).exists(),
+            ".{} must not exist", MAX_ROTATIONS + 1
+        );
+        assert!(
+            rotated_path(&path, MAX_ROTATIONS).exists(),
+            ".{} must exist", MAX_ROTATIONS
+        );
+    }
+
+    // ── Parent dir is created automatically ─────────────────────────────────
+
+    #[test]
+    fn creates_parent_directory() {
+        let dir = test_dir("creates_parent");
+        let path = dir.join("nested").join("deep").join("trace.ndjson");
+        let mut w = TraceWriter::open_with_limit(&path, DEFAULT_SIZE_LIMIT).unwrap();
+        w.write_event(&sample_event()).unwrap();
+        assert!(path.exists());
+    }
+}

--- a/src/test_runner/runs.rs
+++ b/src/test_runner/runs.rs
@@ -48,7 +48,10 @@ fn registry() -> &'static Mutex<HashMap<String, RunState>> {
 
 /// Generate a unique run_id + insert an initial Queued state.
 pub fn new_run(test_id: &str) -> String {
-    let run_id = format!("run_{}", chrono::Local::now().format("%Y%m%d_%H%M%S_%3f"));
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let run_id = format!("run_{}_{seq}", chrono::Local::now().format("%Y%m%d_%H%M%S_%3f"));
     let state = RunState {
         run_id: run_id.clone(),
         test_id: test_id.to_string(),


### PR DESCRIPTION
## Summary

Phase 1 implementation of the two major architectural components planned in the design docs:

**★A Pre-Authorization Engine** (`src/authz/`)
- 3-tier config merge: repo `.sirin/authz.yaml` > `~/.sirin/authz.yaml` > built-in defaults
- Modes: `selective` / `strict` / `permissive` / `plan`
- Rule matching: URL glob (globset), action wildcard (`ax_*`/`*`), `js_contains`, `name_regex`
- Decision types: `Allow` / `Deny` / `Ask` / `AskWithLearn`
- NDJSON audit log
- 32 unit tests

**★B Live Monitor Core** (`src/monitor/`)
- `OnceLock` singleton, `MAX_EVENTS=1000` / `MAX_SCREENSHOTS=50` ring-buffers
- `ServerEvent` internally-tagged serde enum: Hello/ActionStart/ActionDone/AuthzAsk/Screenshot/UrlChange/Console/Network/…
- NDJSON trace writer with 100 MB rotation, 20 backup files
- Poll-based flush (50 ms tick); `emit_*` helpers are no-ops until `init()` called
- 36 unit tests

**Browser fixes**
- `screenshot_jpeg(quality: u8)` API for monitor screenshot stream
- `wait_for_new_tab` baseline source mismatch fix (false-positive new-tab detection)
- `run_id` atomic suffix to prevent parallel test collision

**Dev tooling**
- `scripts/dev-relaunch.sh`: kill → build → port-check → exec chain
- `sirin-dev` skill updated with new gotchas and preferred workflow

## What's next (Phase 2, separate PRs)

- T4: `mcp_server.rs` session ID + client_id + authz gate wired in
- T5: `monitor/screenshot_pump.rs` — periodic JPEG capture thread  
- T6: `ui_egui/monitor/` — egui live action feed + screenshot viewer
- T7: `control.rs` — pause/step/abort commands over WebSocket

## Test plan

- [x] `cargo check` — 0 errors
- [x] `cargo test --bin sirin` — all tests pass (including 32 authz + 36 monitor unit tests)
- [ ] Smoke test: restart Sirin, verify `wait_new_tab` correctly times out (no false-positive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)