### PR TITLE
test(agora): add agora_order_checkout_e2e — 核心下單流程 E2E

### DIFF
--- a/config/tests/agora_regression/agora_order_checkout_e2e.yaml
+++ b/config/tests/agora_regression/agora_order_checkout_e2e.yaml
@@ -1,0 +1,62 @@
+id: agora_order_checkout_e2e
+name: "AgoraMarket 核心下單流程 E2E (Issue #49 / #70 #6,#45,#74)"
+url: "https://redandan.github.io/?__test_role=buyer"
+
+max_iterations: 25
+timeout_secs: 360
+retry_on_parse_error: 5
+
+locale: zh-TW
+perception: vision
+
+# 涵蓋 #70 清單：
+#   #6  訂單建立 / 結帳成功路徑
+#   #45 結帳頁 UI（與 agora_checkout_dry 互補：dry 只驗 UI，這個會真的下單）
+#   #74 訂單列表「我的訂單」呈現
+# 同步驗證 silent bug #3（pickup service type 預設值 non-empty）
+kb_refs:
+  - agora-pickup-flow
+
+goal: |
+  目標：完整跑通買家核心下單 E2E — 登入 → 商品 → 加購 → 結帳 → 選付款 → 下單 → 驗證訂單顯示。
+
+  起始狀態：買家已 auto-login（URL ?__test_role=buyer），位於首頁商品列表。
+
+  ⚠️ Flutter CanvasKit app：UI 判斷一律用 screenshot_analyze（不要依賴 DOM）。
+  ⚠️ 點擊優先 shadow_click（role + name_regex）；找不到才用 click_point + 螢幕座標。
+  ⚠️ 底部 4 個 tab：role=tab name=「商品/訂單/錢包/我的」。
+  ⚠️ 任一步驟失敗仍必須執行到步驟 14 才能 done=true。嚴禁提早終止。
+  ⚠️ 這是 E2E 真實下單，會在後端產生訂單記錄 — 是預期行為（測試帳號）。
+
+  步驟（線性，步驟 14 無條件 done=true，不得提早）：
+  1. wait 3000（等首頁完整載入）
+  2. screenshot_analyze "確認在買家首頁，看到商品卡片列表（含 USDT 價格）"
+  3. shadow_click role=button name_regex="USDT"（點第一個商品卡進入詳情）
+  4. wait 2500
+  5. screenshot_analyze "是否在商品詳情頁？記錄商品名稱、價格、可見的物流/取貨欄位是否有預設值（Bug #3：service type 必須非空白）"
+  6. scroll y=400（捲到底部找購買按鈕）
+  7. shadow_click role=button name_regex="加入購物車|立即購買|確認購買|Buy Now|Add to Cart|購買"
+  8. wait 3000
+  9. screenshot_analyze "點購買後的狀態：是規格選擇彈窗？結帳頁？購物車？記錄看到的標題與按鈕"
+  10. shadow_click role=button name_regex="結帳|前往結帳|去結帳|下一步|確認|Checkout|Continue"
+  11. wait 3000
+  12. screenshot_analyze "結帳頁截圖：訂單摘要、金額、付款方式選項、收貨/取貨資訊欄位是否都有預設值（Bug #3）？「下單/Place Order」按鈕是否可點（非 disabled）？"
+  13. shadow_click role=button name_regex="USDT|錢包餘額|餘額支付|Balance"（選付款方式 — 若已預選則此步驟可能 no-op）
+  14. wait 1500
+  15. shadow_click role=button name_regex="^下單$|^確認下單$|^送出訂單$|^Place Order$|^Submit$"
+  16. wait 4500（等下單請求 + 跳轉）
+  17. screenshot_analyze "下單後的狀態：是否跳到訂單成功頁、訂單詳情、或回到訂單列表？記錄頁面標題與顯示的訂單資訊"
+  18. shadow_click role=tab name_regex="^訂單$"（點底部訂單 tab 確認訂單入列）
+  19. wait 2500
+  20. screenshot_analyze "我的訂單頁截圖：剛下的訂單是否出現在最上方？記錄商品名、金額、狀態（待出貨/待付款/處理中等）"
+  21. done=true
+
+success_criteria:
+  - "成功從商品詳情頁加入購物車或進入結帳"
+  - "成功進入結帳頁，看到訂單摘要與金額"
+  - "結帳頁取貨/物流欄位有預設值（驗證 Bug #3 已修復，無空白 service type）"
+  - "成功點擊下單按鈕並完成下單請求（頁面跳轉或顯示成功訊息）"
+  - "新訂單出現在「我的訂單」列表（含商品名與金額）"
+  - "全程無 'Something went wrong' 錯誤訊息或 console error"
+
+tags: [agora, regression, e2e, checkout, order, issue-49, issue-70, critical]


### PR DESCRIPTION
## Summary

新增 `config/tests/agora_regression/agora_order_checkout_e2e.yaml`，覆蓋 AgoraMarket 買家核心下單 E2E 流程：

- 登入買家 (`?__test_role=buyer` auto-login) → 進商品詳情頁 → 加購物車 / 立即購買 → 結帳頁 → 選付款方式 → 確認下單 → 驗證訂單顯示在「我的訂單」
- 同步驗證 silent bug #3（pickup service type 預設值非空白）— 在步驟 5 與 12 兩處 screenshot_analyze 檢查取貨/物流欄位
- 對應 #70 清單的 #6（訂單建立）、#45（結帳頁 UI）、#74（訂單列表呈現）
- vision mode（Flutter CanvasKit）；max_iterations=25；locale=zh-TW
- 與既有 `agora_checkout_dry.yaml` 互補：dry 只驗 UI 不下單，這個 E2E 真的會送出訂單

文件位置採用 `config/tests/agora_regression/`（與既有的 cart/checkout/pickup/buyer_order_view YAML 同目錄），共 62 LOC。

Closes #49

## Test plan

- [ ] `sirin_call.exe run_test test_id=agora_order_checkout_e2e` 連續 3 次都 pass（驗收條件）
- [ ] 失敗時 screenshot 能定位到具體哪個步驟卡住（步驟 1-21 線性、編號清楚）
- [ ] 確認 vision mode 截圖能看清結帳頁的取貨欄位（驗證 Bug #3）
- [ ] 確認新訂單真的進到後端（避免假成功）

🤖 Generated with [Claude Code](https://claude.com/claude-code)