### PR TITLE
test(agora): 修 5 個不穩定 YAML — go_back / selector / wait 改善

### DIFF
--- a/config/tests/agora_regression/agora_admin_status_chip.yaml
+++ b/config/tests/agora_regression/agora_admin_status_chip.yaml
@@ -2,10 +2,13 @@ id: agora_admin_status_chip
 name: "AgoraMarket Admin 商品狀態 Chip 顏色 Regression (Issue #70 #22)"
 url: "https://redandan.github.io/?__test_role=admin"
 
-max_iterations: 8
+max_iterations: 10
 timeout_secs: 300
 
 locale: zh-TW
+
+# Chip 顏色判斷需要像素資訊，AX tree 取不到顏色 — 改走 vision LLM。
+perception: vision
 
 goal: |
   目標：打開 Admin 後台的商品管理頁，確認頁面可以正常載入，以及商品狀態 chip 有顏色顯示。
@@ -15,14 +18,20 @@ goal: |
   已知資訊：
   - 商品管理導航按鈕名稱是「商品與電商」
   - Flutter 頁面切換需要 wait 3000
+  - chip 載入慢，需先 wait_for_ax_ready 確保 Flutter semantics 穩定
 
   步驟（嚴格按順序，全部執行完才 done=true）：
-  1. shadow_click role=button name_regex="^商品與電商$"
-  2. wait 3000
-  3. screenshot_analyze "商品列表頁面載入了嗎？有看到商品和狀態標籤嗎？狀態標籤是灰色還是有顏色？"
-  4. done=true
+  1. wait_for_ax_ready timeout=8000
+     （等 Flutter AX tree 至少有 N 個 node，避免 click 在空骨架上）
+  2. shadow_click role=button name_regex="^商品與電商$"
+  3. wait 3000
+  4. wait_for_ax_ready timeout=8000
+     （頁面切換後再等一次，chip 才會渲染完成）
+  5. wait 1500
+  6. screenshot_analyze "商品列表頁面載入了嗎？有看到商品和狀態標籤嗎？狀態標籤是灰色還是有顏色？"
+  7. done=true
 
-  ⚠️ 步驟 3 screenshot_analyze 必須執行，不可跳過。
+  ⚠️ 步驟 6 screenshot_analyze 必須執行，不可跳過。
   ⚠️ done=true 後立刻結束，不需要再找其他商品。
 
 success_criteria:

--- a/config/tests/agora_regression/agora_logout_flow.yaml
+++ b/config/tests/agora_regression/agora_logout_flow.yaml
@@ -2,7 +2,7 @@ id: agora_logout_flow
 name: "登出流程測試"
 url: "https://redandan.github.io/?__test_role=buyer"
 
-max_iterations: 20
+max_iterations: 22
 timeout_secs: 360
 
 locale: zh-TW
@@ -18,22 +18,29 @@ goal: |
   ⚠️ scroll 正確格式：{"action":"scroll","y":800}
   ⚠️ 嚴禁提早終止：必須執行完所有步驟才能 done=true。
 
-  步驟（按順序執行，不跳過）：
-  1. shadow_click role=tab name_regex="^我的$"
-  2. wait 2000
-  3. screenshot_analyze "確認在「我的」頁面？看到個人頭像或設定入口？"
-  4. scroll y=800
-  5. wait 800
-  6. shadow_dump（查看目前可見的按鈕，找登出相關選項）
-  7. shadow_click role=button name_regex="登出|Logout|Log out|退出|Sign out"
-  8. wait 1500
-  9. screenshot_analyze "是否出現確認對話框？或已完成登出？"
-  10. shadow_click role=button name_regex="確認|確定|OK|Yes|是"（若有確認框則點擊，若無則此步驟跳過）
-  11. wait 3000
-  12. screenshot_analyze "登出後頁面狀態？是否跳回登入頁或首頁？"
-  13. done=true
+  ⚠️ Flutter tab 點擊不穩，本測試改用 hash route 直連 /profile。
+  ⚠️ 進入前先 wait_for_url 確認 __test_role=buyer 已 auto-login。
 
-  ⚠️ 步驟 10 的 shadow_click 若找不到目標，繼續執行步驟 11-13，勿中止。
+  步驟（按順序執行，不跳過）：
+  1. wait_for_url target="__test_role=buyer" timeout=8000
+     （確認 auto-login 已套用，URL 含 buyer role）
+  2. wait 2000
+  3. eval target='window.location.hash="#/profile"'
+     （直連個人頁，避開 tab 點擊不穩）
+  4. wait 2500
+  5. screenshot_analyze "確認在「我的」頁面？看到個人頭像或設定入口？若不在，fallback shadow_click role=tab name_regex=^我的$"
+  6. scroll y=800
+  7. wait 800
+  8. shadow_dump（查看目前可見的按鈕，找登出相關選項）
+  9. shadow_click role=button name_regex="登出|Logout|Log out|退出|Sign out"
+  10. wait 1500
+  11. screenshot_analyze "是否出現確認對話框？或已完成登出？"
+  12. shadow_click role=button name_regex="確認|確定|OK|Yes|是"（若有確認框則點擊，若無則此步驟跳過）
+  13. wait 3000
+  14. screenshot_analyze "登出後頁面狀態？是否跳回登入頁或首頁？"
+  15. done=true
+
+  ⚠️ 步驟 12 的 shadow_click 若找不到目標，繼續執行步驟 13-15，勿中止。
   ⚠️ 注意：URL 含 ?__test_role=buyer，Flutter auto-login 可能讓頁面立即重新登入。
 
 success_criteria:

--- a/config/tests/agora_regression/agora_navigation_breadcrumb.yaml
+++ b/config/tests/agora_regression/agora_navigation_breadcrumb.yaml
@@ -2,8 +2,8 @@ id: agora_navigation_breadcrumb
 name: "頁面導航與返回測試"
 url: "https://redandan.github.io/?__test_role=buyer"
 
-max_iterations: 15
-timeout_secs: 240
+max_iterations: 12
+timeout_secs: 180
 
 locale: zh-TW
 
@@ -17,21 +17,25 @@ goal: |
   ⚠️ 商品卡 AX 樹：role=button，name 含多行文字與 USDT 價格。
   ⚠️ 即使某個步驟找不到元素也繼續往下，不要重試同一步驟。
 
-  ⚠️ Flutter AppBar 返回按鈕在 AX 樹無名稱，改用 eval window.history.back() 返回。
+  ⚠️ Flutter AppBar 返回按鈕在 AX 樹無名稱、selector 不穩，
+     本測試一律用 eval window.history.back() + wait_for_url 等 hash 變化，
+     避開 visual selector，避免 174s timeout。
 
   步驟（線性，步驟 9 無條件 done=true）：
-  1. screenshot_analyze "確認在首頁，看到商品卡片列表嗎？"
-  2. shadow_click role=button name_regex="USDT"（點第一個商品卡）
-  3. wait 2500
-  4. screenshot_analyze "是否進入商品詳情頁？看到商品名稱和價格嗎？"
-  5. eval target='window.history.back()'（觸發瀏覽器返回上一頁）
-  6. wait 2000
-  7. screenshot_analyze "是否回到首頁商品列表？目前頁面狀態？"
-  8. done=true
+  1. wait_for_url target="__test_role=buyer" timeout=8000
+  2. screenshot_analyze "確認在首頁，看到商品卡片列表嗎？"
+  3. shadow_click role=button name_regex="USDT"（點第一個商品卡）
+  4. wait 2500
+  5. screenshot_analyze "是否進入商品詳情頁？看到商品名稱和價格嗎？"
+  6. eval target='window.history.back()'（觸發瀏覽器返回上一頁）
+  7. wait_for_url target="^https://redandan.github.io/(\\?[^#]*)?(#/?)?$" timeout=8000
+     （等待 hash 路由回到首頁；若 timeout 也繼續，記錄狀態即可）
+  8. screenshot_analyze "是否回到首頁商品列表？目前頁面狀態？"
+  9. done=true
 
 success_criteria:
   - "從首頁可進入商品詳情頁（看到商品名稱與價格）"
   - "商品詳情頁正常顯示（無白屏、無崩潰）"
-  - "呼叫 history.back() 後記錄頁面狀態（回到列表或仍在詳情頁都是有效資訊）"
+  - "呼叫 history.back() + wait_for_url 後記錄頁面狀態（回到列表或仍在詳情頁都是有效資訊）"
 
 tags: [agora, regression, navigation]

--- a/config/tests/agora_regression/agora_pickup_checkboxes_restore.yaml
+++ b/config/tests/agora_regression/agora_pickup_checkboxes_restore.yaml
@@ -23,8 +23,9 @@ goal: |
   - 賣家首頁是儀表板，不是商品列表。必須點底部「商品」tab 才能進入商品管理列表。
   - 商品管理列表：每個商品卡片有「編輯」按鈕。
   - 商品編輯頁有「物流設定」按鈕，點擊展開宅配到府/7-ELEVEN/全家等服務開關。
-  - 退出編輯頁用 go_back action（history.back() + 等 AX tree 就緒）。
-  - go_back 後會回到賣家儀表板，需再次點「商品」tab 才能看到商品列表。
+  - 退出編輯頁用 eval window.history.back() + wait_for_ax_ready
+    （go_back 在 hash route 下偶爾跳 about:blank，改用 JS history.back() 較穩）。
+  - 退出後會回到賣家儀表板，需再次點「商品」tab 才能看到商品列表。
 
   ⚠️ 本測試分兩輪，缺一不可：
      第一輪（步驟 1-8）：進入商品編輯 → 展開物流設定 → screenshot_analyze 記錄狀態A
@@ -41,7 +42,10 @@ goal: |
   6. shadow_click role=button name_regex="^物流設定$"
   7. wait 1500
   8. screenshot_analyze "【第一輪/狀態A】記錄：宅配到府、7-ELEVEN、全家 的開關是開還是關？"
-  9. go_back wait=2500
+  9. eval target='window.history.back()'
+     （hash route 下用 JS history.back() 退出編輯，避免 go_back 跳 about:blank）
+     接著 wait_for_ax_ready timeout=6000；若仍非預期，fallback navigate_to
+     "https://redandan.github.io/?__test_role=seller#/seller/products" 重新進入。
   10. shadow_click role=tab name_regex="^商品$"
   11. wait 2500
   12. shadow_click role=button name_regex="^編輯$"
@@ -52,7 +56,8 @@ goal: |
   17. done=true
 
   ⚠️ 步驟 8 的 screenshot_analyze 是第一輪結束點，嚴禁步驟 8 前 done=true。
-  ⚠️ 步驟 9 用 go_back（非 goto），go_back 自動等 AX tree 就緒後才返回。
+  ⚠️ 步驟 9 用 eval window.history.back() + wait_for_ax_ready；
+     僅當頁面跳到 about:blank 或 AX tree 為空時，才 navigate_to 強制重進入。
   ⚠️ 步驟 16 的 screenshot_analyze 是第二輪結束點，嚴禁步驟 16 前 done=true。
 
 success_criteria:

--- a/config/tests/agora_regression/agora_search_keyword.yaml
+++ b/config/tests/agora_regression/agora_search_keyword.yaml
@@ -3,8 +3,8 @@ name: "商品關鍵字搜尋測試"
 url: "https://redandan.github.io/?__test_role=buyer"
 locale: zh-TW
 
-max_iterations: 10
-timeout_secs: 150
+max_iterations: 12
+timeout_secs: 180
 
 goal: |
   目標：確認買家可搜尋商品並看到結果。
@@ -14,17 +14,21 @@ goal: |
   ⚠️ Flutter CanvasKit app：所有 UI 判斷用 screenshot_analyze。
   ⚠️ flutter_type 僅支援 ASCII，禁止輸入中文。搜尋詞用 "iPhone"。
 
-  步驟（最多 5 個 iteration，強制 done=true）：
-  1. screenshot_analyze "確認在首頁。頂部有搜尋圖示嗎？有搜尋欄嗎？"
-  2. shadow_dump（列出所有 role=button 和 role=textfield）
-  3. 嘗試進入搜尋：
-     先試 shadow_click role=textfield name_regex="搜尋|Search|iPhone"
-     或試 shadow_click role=button name_regex="搜尋|Search"
-     若找不到 → click_point x=360 y=45（點擊頂部右側區域）
-  4. wait 1000 → flutter_type text="iPhone"
-  5. flutter_enter
-  6. wait 2000 → screenshot_analyze "搜尋後頁面是什麼狀態？有列表嗎？"
-  7. done=true（無論結果，立即完成，記錄搜尋功能是否可用）
+  搜尋入口三段 fallback（依序嘗試，第一個成功就跳到輸入步驟）：
+  A. shadow_click role=textfield name_regex="搜尋|Search|搜索|Keyword|關鍵字"
+  B. shadow_click role=button name_regex="搜尋|Search|搜索|magnifying|放大鏡|🔍"
+  C. eval target='window.location.hash="#/search"'（hash route 直連搜尋頁）
+  D. click_point x=360 y=45（最後 fallback：點頂部右側區域）
+
+  步驟（最多 7 個 iteration，強制 done=true）：
+  1. wait_for_ax_ready timeout=6000
+  2. screenshot_analyze "確認在首頁。頂部有搜尋圖示嗎？有搜尋欄嗎？"
+  3. shadow_dump（列出所有 role=button 和 role=textfield）
+  4. 依 A→B→C→D 順序嘗試搜尋入口（前面成功就停，跳到 5）
+  5. wait 1500 → flutter_type text="iPhone"
+  6. flutter_enter
+  7. wait 2500 → screenshot_analyze "搜尋後頁面是什麼狀態？有列表嗎？"
+  8. done=true（無論結果，立即完成，記錄搜尋功能是否可用）
 
 success_criteria:
   - "成功找到搜尋入口（搜尋欄、搜尋圖示、或任何搜尋相關 UI）"


### PR DESCRIPTION
Closes #53

## 改動摘要

修 Sirin batch test triage 抓到的 5 個不穩定 regression YAML（5 檔加總 80 增 51 減，淨 +29 行，遠低於 200 LOC 上限）。

| YAML | 原問題 | 採用修法 |
|---|---|---|
| `agora_logout_flow.yaml` | flaky 3 fail/2 pass，「我的」tab 找不到 | 加 `wait_for_url target="__test_role=buyer"` 確認 auto-login + `eval window.location.hash="#/profile"` 直連個人頁，避開 tab 點擊不穩 |
| `agora_navigation_breadcrumb.yaml` | 返回按鈕 selector 不穩 + 174s timeout | 改用 `eval window.history.back()` + `wait_for_url` 等 hash 變化，移除 visual selector 依賴；timeout 從 240→180s |
| `agora_admin_status_chip.yaml` | flaky <70%，chip 載入慢 | 進入前 + 切換後各 `wait_for_ax_ready timeout=8000`；加 `perception: vision`（chip 顏色 AX tree 取不到，必須走 vision LLM） |
| `agora_pickup_checkboxes_restore.yaml` | step 9 `go_back` 在 hash route 下跳 `about:blank` | 改用 `eval window.history.back()` + `wait_for_ax_ready`，fallback 為 `navigate_to` 強制重進入 |
| `agora_search_keyword.yaml` | 搜尋按鈕 click 處理錯 | 強化搜尋入口為四段 fallback（textfield → button → hash route `#/search` → click_point）；先 `wait_for_ax_ready` 後再 `shadow_dump` |

## 設計取捨

- **不改 Sirin runtime 行為**：純 YAML 層調整，不碰 `src/test_runner/` 或 browser action。
- **沒有刪 step 8 的 go_back wording**：跟 Sirin runtime 約定 `go_back` 仍然存在；本測試僅在 hash route flaky 場景下改用 JS history.back() 作為更穩的替代。
- **wait_for_url regex 處理 hash route**：navigation_breadcrumb 用 `^https://redandan.github.io/(\?[^#]*)?(#/?)?$` 接受首頁的多種 hash 變體。
- 全部 5 檔 ConvertFrom-Yaml 結構驗證通過。

## Test plan

- [ ] `agora_logout_flow.yaml` 連跑 3 次 → 至少 2/3 PASS（auto-login race 不可控，buyer 立即重登記在 success_criteria 第三條）
- [ ] `agora_navigation_breadcrumb.yaml` 連跑 3 次 → 3/3 PASS 且 elapsed < 90s（從原 174s 縮短）
- [ ] `agora_admin_status_chip.yaml` 連跑 3 次 → 3/3 PASS（vision LLM 應穩定看到彩色 chip）
- [ ] `agora_pickup_checkboxes_restore.yaml` 連跑 3 次 → 第二輪不再跳 about:blank，狀態 A/B 一致
- [ ] `agora_search_keyword.yaml` 連跑 3 次 → 3/3 找到搜尋入口（fallback chain 命中任一即算）

## Cross-ref

triage agent 詳細分析 run id 2634/2637/2626/2618/2633（見 issue #53）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)