### PR TITLE
feat: wire test_dashboard to failure events + step progress

### DIFF
--- a/src/ui_egui/test_dashboard.rs
+++ b/src/ui_egui/test_dashboard.rs
@@ -380,6 +380,42 @@ fn show_run_row(ui: &mut egui::Ui, run: &TestRunView) {
                     theme::TEXT,
                     RichText::new(&run.test_id).size(theme::FONT_BODY),
                 );
+
+                // Live step counter for active runs (Issue #31).
+                if let Some(step) = run.step {
+                    ui.colored_label(
+                        theme::INFO,
+                        RichText::new(format!("step {step}"))
+                            .size(theme::FONT_CAPTION)
+                            .monospace(),
+                    );
+                }
+
+                // Triage category badge for failed history rows.
+                if let Some(cat) = &run.failure_category {
+                    if !cat.is_empty() {
+                        ui.colored_label(
+                            theme::DANGER,
+                            RichText::new(format!("[{cat}]"))
+                                .size(theme::FONT_CAPTION)
+                                .monospace(),
+                        );
+                    }
+                }
+
+                // Flaky tag — pass rate < 70% over the visible window.
+                if let Some(pr) = run.pass_rate {
+                    if pr < 0.70 {
+                        ui.colored_label(
+                            theme::YELLOW,
+                            RichText::new(format!("flaky {:.0}%", pr * 100.0))
+                                .size(theme::FONT_CAPTION)
+                                .monospace(),
+                        )
+                        .on_hover_text("pass rate < 70% over recent runs");
+                    }
+                }
+
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     if let Some(ms) = run.duration_ms {
                         let s = ms / 1000;

--- a/src/ui_service.rs
+++ b/src/ui_service.rs
@@ -246,6 +246,17 @@ pub struct TestRunView {
     pub duration_ms: Option<u64>,
     /// Short AI analysis or current action (truncated by UI).
     pub analysis:    Option<String>,
+    /// Current step index (only populated for active `RunPhase::Running`).
+    /// Drives the live progress indicator on the dashboard.
+    pub step:              Option<u32>,
+    /// Triage category for failed runs (e.g. "selector_not_found",
+    /// "timeout", "ai_assertion_failed").  None for passed/active runs.
+    pub failure_category:  Option<String>,
+    /// Pass rate for this `test_id` over the recent history window
+    /// (0.0..=1.0).  Populated only by `recent_test_runs` so the UI
+    /// can flag flaky tests (< 70%).  None for active rows or single-run
+    /// histories.
+    pub pass_rate:         Option<f32>,
 }
 
 // ── Service traits ───────────────────────────────────────────────────────────

--- a/src/ui_service_impl/mod.rs
+++ b/src/ui_service_impl/mod.rs
@@ -202,14 +202,43 @@ impl MultiAgentService for RealService {
 
 impl TestRunnerService for RealService {
     fn recent_test_runs(&self, limit: usize) -> Vec<TestRunView> {
-        crate::test_runner::store::recent_runs_all(limit)
-            .into_iter()
+        let rows = crate::test_runner::store::recent_runs_all(limit);
+
+        // Compute per-test_id pass rate over the visible window so the UI
+        // can flag flaky tests inline (Issue #31).  Only counts terminal
+        // statuses — running/queued rows are excluded from the denominator.
+        use std::collections::HashMap;
+        let mut totals: HashMap<String, (u32, u32)> = HashMap::new(); // (passed, total)
+        for r in &rows {
+            match r.status.as_str() {
+                "passed" => {
+                    let e = totals.entry(r.test_id.clone()).or_insert((0, 0));
+                    e.0 += 1; e.1 += 1;
+                }
+                "failed" | "error" | "timeout" => {
+                    let e = totals.entry(r.test_id.clone()).or_insert((0, 0));
+                    e.1 += 1;
+                }
+                _ => {}
+            }
+        }
+        // Need at least 2 terminal runs to call something flaky vs. a one-off.
+        let pass_rate_for = |id: &str| -> Option<f32> {
+            let (p, t) = totals.get(id).copied()?;
+            if t < 2 { return None; }
+            Some(p as f32 / t as f32)
+        };
+
+        rows.into_iter()
             .map(|r| TestRunView {
-                test_id:     r.test_id,
-                status:      r.status,
-                started_at:  r.started_at,
-                duration_ms: r.duration_ms.map(|d| d as u64),
-                analysis:    r.ai_analysis,
+                pass_rate:        pass_rate_for(&r.test_id),
+                test_id:          r.test_id,
+                status:           r.status,
+                started_at:       r.started_at,
+                duration_ms:      r.duration_ms.map(|d| d as u64),
+                analysis:         r.ai_analysis,
+                step:             None,
+                failure_category: r.failure_category,
             })
             .collect()
     }
@@ -220,18 +249,21 @@ impl TestRunnerService for RealService {
             .into_iter()
             .filter_map(|run_id| get(&run_id))
             .map(|s| {
-                let (status, analysis) = match &s.phase {
-                    RunPhase::Queued => ("queued".to_string(), None),
-                    RunPhase::Running { current_action, .. } =>
-                        ("running".to_string(), Some(current_action.clone())),
-                    _ => ("unknown".to_string(), None),
+                let (status, analysis, step) = match &s.phase {
+                    RunPhase::Queued => ("queued".to_string(), None, None),
+                    RunPhase::Running { current_action, step } =>
+                        ("running".to_string(), Some(current_action.clone()), Some(*step)),
+                    _ => ("unknown".to_string(), None, None),
                 };
                 TestRunView {
-                    test_id:     s.test_id.clone(),
+                    test_id:          s.test_id.clone(),
                     status,
-                    started_at:  s.started_at.clone(),
-                    duration_ms: None,
+                    started_at:       s.started_at.clone(),
+                    duration_ms:      None,
                     analysis,
+                    step,
+                    failure_category: None,
+                    pass_rate:        None,
                 }
             })
             .collect()


### PR DESCRIPTION
## Summary
- `TestRunView` gains `step`, `failure_category`, and `pass_rate` so the dashboard can surface live progress and flakiness from data the runner already produces.
- `active_test_runs()` propagates `RunPhase::Running { step, .. }` from the in-memory registry; `recent_test_runs()` aggregates pass-rate per `test_id` over the visible window and forwards `failure_category` from SQLite.
- `show_run_row()` renders three new badges next to the `test_id`, following the hardcore theme:
  - step counter (INFO blue, monospace) for active rows
  - `[category]` (DANGER red, monospace) for failed history rows
  - `flaky N%` (YELLOW) when pass-rate < 70% over >= 2 terminal runs, with a hover tooltip explaining the rule

The existing 3-second poll loop drives all of this — no new subscription channel, no egui state-machine surgery. Repaint already runs while active runs exist, so step changes show up within a frame of the next 3 s refresh.

## Test plan
- [x] `cargo check --bin sirin` clean (no errors)
- [ ] Manual: launch a YAML test from the dashboard → active row shows `step N` while running, increments as the ReAct loop progresses
- [ ] Manual: trigger a failing run → history row shows red `[category]` badge with the triage label
- [ ] Manual: re-run a flaky test enough times that pass-rate dips < 70% → yellow `flaky N%` badge appears on its history rows

Closes #31

Generated with [Claude Code](https://claude.com/claude-code)