### PR TITLE
feat(kb): write triage result to KB — persist UiBug/ApiBug classification

### DIFF
--- a/src/test_runner/mod.rs
+++ b/src/test_runner/mod.rs
@@ -102,6 +102,29 @@ async fn run_test_with_run_id(
     } else {
         let outcome = triage::triage(ctx, &test, &result).await;
         let triggered = auto_fix && triage::trigger_auto_fix(&test, &result, &outcome, run_id).await;
+
+        // Issue #34: persist triage classification to KB so future sessions can
+        // run `kbSearch("UiBug", project="sirin")` instead of reaching for
+        // SQLite.  Fire-and-forget — KB outage must never break a test run.
+        // Same shape as the failure / pass write-backs in `runs.rs::set_phase`.
+        // Uses a distinct topic key (`sirin-triage-{test_id}`) so it does not
+        // race with the failure writer that already targets
+        // `sirin-failure-{test_id}` from `runs.rs`.
+        let test_id_kb  = test.id.clone();
+        let category_kb = outcome.category.as_str().to_string();
+        let reason_kb   = outcome.reason.clone();
+        let auto_fix_kb = triggered;
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                let (topic_key, title, content, tags) =
+                    triage::render_kb_entry(&test_id_kb, &category_kb, auto_fix_kb, &reason_kb);
+                let _ = crate::kb_client::write_raw_to_project(
+                    "sirin", &topic_key, &title, &content,
+                    "testing", &tags, "",
+                ).await;
+            });
+        }
+
         (
             Some(outcome.category.as_str().to_string()),
             Some(outcome.reason.clone()),

--- a/src/test_runner/triage.rs
+++ b/src/test_runner/triage.rs
@@ -334,6 +334,30 @@ pub async fn trigger_auto_fix(test: &TestGoal, result: &TestResult, outcome: &Tr
     true
 }
 
+/// Render the (topic_key, title, content, tags) tuple used by the Issue #34
+/// fire-and-forget KB write-back.  Pulled out as a free function so the
+/// rendered shape can be unit-tested without spawning a tokio task.
+///
+/// `category` is the lowercase string form (`ui_bug`, `api_bug`, ...),
+/// `auto_fix` mirrors `TriageOutcome::auto_fix_triggered` after the auto-fix
+/// branch has run.  `reason` is the LLM (or rule-based) classification reason.
+pub fn render_kb_entry(
+    test_id: &str,
+    category: &str,
+    auto_fix: bool,
+    reason: &str,
+) -> (String, String, String, String) {
+    let topic_key = format!("sirin-triage-{test_id}");
+    let title     = format!("[TRIAGE] {test_id} → {category}");
+    let content   = format!(
+        "triage: {category}\n\
+         auto_fix_attempted: {auto_fix}\n\
+         reason: {reason}"
+    );
+    let tags = format!("triage,{category}");
+    (topic_key, title, content, tags)
+}
+
 /// Build a short summary of recent fix attempts to give Claude context.
 fn format_recent_fix_context(test_id: &str) -> String {
     let recent = super::store::recent_fixes(test_id, 3);
@@ -499,6 +523,39 @@ mod tests {
         std::fs::write(&path, vec![42u8; 20_000]).unwrap();
         assert!(!is_screenshot_all_black(path.to_str().unwrap()));
         let _ = std::fs::remove_file(path);
+    }
+
+    // ── Issue #34: triage → KB rendering ────────────────────────────────
+
+    #[test]
+    fn render_kb_entry_basic_ui_bug() {
+        let (topic, title, content, tags) =
+            render_kb_entry("agora-pickup-flow", "ui_bug", true, "按鈕沒渲染");
+        assert_eq!(topic, "sirin-triage-agora-pickup-flow");
+        assert_eq!(title, "[TRIAGE] agora-pickup-flow → ui_bug");
+        assert!(content.contains("triage: ui_bug"),         "got: {content}");
+        assert!(content.contains("auto_fix_attempted: true"), "got: {content}");
+        assert!(content.contains("reason: 按鈕沒渲染"),       "got: {content}");
+        assert_eq!(tags, "triage,ui_bug");
+    }
+
+    #[test]
+    fn render_kb_entry_no_auto_fix() {
+        let (_topic, _title, content, tags) =
+            render_kb_entry("flaky-test", "flaky", false, "<70% pass rate");
+        assert!(content.contains("auto_fix_attempted: false"), "got: {content}");
+        assert_eq!(tags, "triage,flaky");
+    }
+
+    #[test]
+    fn render_kb_entry_rendering_failure_no_auto_fix() {
+        // RenderingFailure must never trigger auto-fix — the tag must reflect
+        // the category accurately so kbSearch("rendering_failure") finds it.
+        let (_topic, title, content, tags) =
+            render_kb_entry("k14-exact", "rendering_failure", false, "all-black screenshot");
+        assert!(title.contains("rendering_failure"));
+        assert!(content.contains("auto_fix_attempted: false"));
+        assert_eq!(tags, "triage,rendering_failure");
     }
 
     #[test]


### PR DESCRIPTION
Closes #34

## Summary

- Triage already classifies every non-pass into `UiBug` / `ApiBug` / `Flaky` / `Env` / `Obsolete` / `RenderingFailure` / `Unknown` and writes the category to `store.db`'s `failure_category`.  But KB has no record of it — a review session asking *"has this test been UiBug-flagged this week?"* has to crack open SQLite manually.
- After `triage::triage()` returns inside `test_runner::run_test`, fire-and-forget upsert a `sirin-triage-{test_id}` KB entry capturing `category` + `auto_fix_attempted` flag + LLM `reason`. Mirrors the existing `runs.rs::set_phase` failure/pass write-backs — no new state machine, no extra env-vars, KB outage cannot break a test run, `KB_ENABLED` gate already short-circuits inside `write_raw_to_project`.
- Distinct topic key (`sirin-triage-…`) deliberately avoids racing the `sirin-failure-…` writer in `runs.rs`. `kbSearch("UiBug", project="sirin")` now surfaces every recent UiBug classification, satisfying the issue's acceptance criterion.

## Diff size

- 2 files changed, +80 LOC, 0 deletions. Inside the ≤200 LOC budget the issue specified.

## Test plan

- [x] `cargo check` clean (0 errors).
- [x] 3 new unit tests on `render_kb_entry` (extracted as a free fn so payload shape is testable without spawning tokio): ui_bug w/ auto_fix, flaky w/o auto_fix, rendering_failure (must never carry `auto_fix_attempted=true`). `cargo test --bin sirin test_runner::triage` → 12/12 green.
- [ ] Live verification (post-merge, requires `KB_ENABLED=1`): run any failing YAML test → `kbSearch("UiBug", project="sirin")` should return the new `sirin-triage-{test_id}` entry.

## Notes

- Idempotent topic key means repeated CI failures of the same test collapse via KB's auto-versioning rather than spamming new entries — same property as #33's pass writer.
- Tag list is `triage,{category}` so `kbSearch("triage")` and `kbSearch("rendering_failure")` both retrieve the right slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)