### PR TITLE
feat: test_analytics MCP tool + weekly TG digest formatter

### DIFF
--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -438,6 +438,16 @@ fn handle_tools_list() -> Result<Value, String> {
                 }
             },
             {
+                "name": "test_analytics",
+                "description": "聚合測試健康指標：pass rate (近 10 / 30 runs)、flaky 標記、avg iterations、avg duration、最常見 failure_category。不指定 test_id 時返回全部測試（依 pass_rate_7d 升序，最差優先）+ summary 區塊。",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "test_id": { "type": "string", "description": "選填：只看特定測試" }
+                    }
+                }
+            },
+            {
                 "name": "list_fixes",
                 "description": "查詢 auto-fix 歷史（claude_session spawn 記錄）。能看到哪些 test 觸發過自動修復、結果如何。",
                 "inputSchema": {
@@ -744,6 +754,7 @@ async fn handle_tools_call(params: Value, user_agent: &str) -> Result<Value, Str
         "get_screenshot"       => return call_get_screenshot(arguments).map(wrap_json),
         "get_full_observation" => return call_get_full_observation(arguments).map(wrap_json),
         "list_recent_runs"     => return call_list_recent_runs(arguments).map(wrap_json),
+        "test_analytics"       => return call_test_analytics(arguments).map(wrap_json),
         "list_fixes"           => return call_list_fixes(arguments).map(wrap_json),
         "config_diagnostics"   => return call_config_diagnostics().map(wrap_json),
         "diagnose"             => return Ok(wrap_json(crate::diagnose::snapshot())),
@@ -1057,6 +1068,37 @@ fn call_list_recent_runs(args: Value) -> Result<Value, String> {
         "screenshot_path":  r.screenshot_path,
     })).collect();
     Ok(json!({ "count": items.len(), "runs": items }))
+}
+
+fn call_test_analytics(args: Value) -> Result<Value, String> {
+    let test_id = args.get("test_id").and_then(Value::as_str);
+    let stats = match test_id {
+        Some(tid) => vec![crate::test_runner::store::test_stats(tid)],
+        None      => crate::test_runner::store::all_test_stats(),
+    };
+    let total_tests = stats.len();
+    let flaky_count = stats.iter().filter(|s| s.is_flaky).count();
+    let avg_pass_rate = if total_tests == 0 { 0.0 } else {
+        stats.iter().map(|s| s.pass_rate_7d).sum::<f64>() / total_tests as f64
+    };
+    let items: Vec<Value> = stats.iter().map(|s| json!({
+        "test_id":              s.test_id,
+        "total_runs":           s.total_runs,
+        "pass_rate_7d":         s.pass_rate_7d,
+        "pass_rate_30d":        s.pass_rate_30d,
+        "is_flaky":             s.is_flaky,
+        "avg_iterations":       s.avg_iterations,
+        "avg_duration_ms":      s.avg_duration_ms,
+        "top_failure_category": s.top_failure_category,
+    })).collect();
+    Ok(json!({
+        "tests":   items,
+        "summary": {
+            "total_tests":   total_tests,
+            "flaky_count":   flaky_count,
+            "avg_pass_rate": avg_pass_rate,
+        }
+    }))
 }
 
 fn call_list_fixes(args: Value) -> Result<Value, String> {

--- a/src/test_runner/notify.rs
+++ b/src/test_runner/notify.rs
@@ -43,6 +43,65 @@ pub fn notify_failure(test_name: &str, reason: &str, duration_ms: u64) {
     });
 }
 
+/// Format a weekly test-health digest from current `store::all_test_stats()`.
+///
+/// Pure formatter — no I/O.  Returned `None` when there is no run history
+/// at all, so callers can skip empty TG sends.
+pub fn format_weekly_digest() -> Option<String> {
+    let stats = crate::test_runner::store::all_test_stats();
+    if stats.is_empty() { return None; }
+    let total = stats.len();
+    let flaky_count = stats.iter().filter(|s| s.is_flaky).count();
+    let avg_pass: f64 = stats.iter().map(|s| s.pass_rate_7d).sum::<f64>() / total as f64;
+    let worst: Vec<&crate::test_runner::store::TestStats> = stats.iter()
+        .filter(|s| s.pass_rate_7d < 0.7)
+        .take(3)
+        .collect();
+
+    let mut msg = format!(
+        "Weekly Test Health | {total} tests | avg pass {:.0}% | {flaky_count} flaky",
+        avg_pass * 100.0,
+    );
+    if !worst.is_empty() {
+        msg.push_str("\nWorst:");
+        for s in &worst {
+            msg.push_str(&format!(
+                "\n  {} {:.0}% ({} runs)",
+                s.test_id,
+                s.pass_rate_7d * 100.0,
+                s.total_runs,
+            ));
+        }
+    }
+    Some(msg)
+}
+
+/// Fire-and-forget weekly digest send.  Same env-var contract as
+/// `notify_failure` — silently skipped when SIRIN_NOTIFY_BOT_TOKEN /
+/// SIRIN_NOTIFY_CHAT_ID are unset.  Caller decides scheduling (no cron
+/// framework wired here yet — see Issue #35 follow-up).
+pub fn weekly_test_digest() {
+    let Some(msg) = format_weekly_digest() else { return; };
+    let token = match std::env::var("SIRIN_NOTIFY_BOT_TOKEN") {
+        Ok(t) if !t.is_empty() => t,
+        _ => return,
+    };
+    let chat_id = match std::env::var("SIRIN_NOTIFY_CHAT_ID") {
+        Ok(c) if !c.is_empty() => c,
+        _ => return,
+    };
+    std::thread::spawn(move || {
+        let url = format!("https://api.telegram.org/bot{token}/sendMessage");
+        if let Err(e) = reqwest::blocking::Client::new()
+            .post(&url)
+            .json(&serde_json::json!({ "chat_id": chat_id, "text": msg }))
+            .send()
+        {
+            tracing::warn!(target: "sirin", "[notify] weekly digest send failed: {e}");
+        }
+    });
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/src/test_runner/store.rs
+++ b/src/test_runner/store.rs
@@ -251,6 +251,102 @@ pub fn is_flaky(test_id: &str) -> bool {
     passed > 0 && failed > 0 && (passed as f64 / runs.len() as f64) < 0.70
 }
 
+// ── Analytics aggregates (Issue #35) ─────────────────────────────────────────
+
+/// Aggregate health metrics for a single test.  Values default to safe
+/// neutrals when there is no run history.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TestStats {
+    pub test_id: String,
+    pub total_runs: usize,
+    /// Pass ratio over the last 10 runs (0.0–1.0).
+    pub pass_rate_7d: f64,
+    /// Pass ratio over the last 30 runs (0.0–1.0).
+    pub pass_rate_30d: f64,
+    pub is_flaky: bool,
+    /// Mean iterations consumed across the last 30 runs (0.0 if unknown).
+    pub avg_iterations: f64,
+    /// Mean duration_ms across the last 30 runs (0 if unknown).
+    pub avg_duration_ms: i64,
+    /// Most common failure_category across the last 30 runs, if any.
+    pub top_failure_category: Option<String>,
+}
+
+/// Compute aggregate health metrics for `test_id` from `test_runs`.
+pub fn test_stats(test_id: &str) -> TestStats {
+    let last30 = recent_runs(test_id, 30);
+    let total_runs = last30.len();
+
+    let pass_rate_7d = success_rate(test_id, 10);
+    let pass_rate_30d = success_rate(test_id, 30);
+    let flaky = is_flaky(test_id);
+
+    // avg iterations + duration: pull from SQLite with one aggregate query
+    // (the RunRecord row type omits these columns).
+    let (avg_iters, avg_dur): (f64, i64) = {
+        let conn = db().lock().unwrap_or_else(|e| e.into_inner());
+        conn.query_row(
+            "SELECT COALESCE(AVG(iterations), 0.0), COALESCE(CAST(AVG(duration_ms) AS INTEGER), 0) \
+             FROM (SELECT iterations, duration_ms FROM test_runs \
+                   WHERE test_id = ?1 ORDER BY started_at DESC LIMIT 30)",
+            rusqlite::params![test_id],
+            |row| Ok((row.get(0).unwrap_or(0.0), row.get(1).unwrap_or(0))),
+        ).unwrap_or((0.0, 0))
+    };
+
+    // Top failure category: tally non-null categories across last 30 runs.
+    let mut cat_counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for r in &last30 {
+        if let Some(c) = &r.failure_category {
+            *cat_counts.entry(c.clone()).or_insert(0) += 1;
+        }
+    }
+    let top_failure_category = cat_counts.into_iter().max_by_key(|(_, n)| *n).map(|(c, _)| c);
+
+    TestStats {
+        test_id: test_id.to_string(),
+        total_runs,
+        pass_rate_7d,
+        pass_rate_30d,
+        is_flaky: flaky,
+        avg_iterations: avg_iters,
+        avg_duration_ms: avg_dur,
+        top_failure_category,
+    }
+}
+
+/// Aggregate health metrics for every test that has at least one row in
+/// `test_runs`.  Sorted by `pass_rate_7d` ascending (worst first) so callers
+/// can take(N) for "needs attention" lists.
+pub fn all_test_stats() -> Vec<TestStats> {
+    let conn = db().lock().unwrap_or_else(|e| e.into_inner());
+    let mut stmt = match conn.prepare("SELECT DISTINCT test_id FROM test_runs") {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let ids: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .map(|it| it.filter_map(Result::ok).collect())
+        .unwrap_or_default();
+    drop(stmt);
+    drop(conn);
+
+    let mut stats: Vec<TestStats> = ids.iter().map(|id| test_stats(id)).collect();
+    stats.sort_by(|a, b| a.pass_rate_7d.partial_cmp(&b.pass_rate_7d).unwrap_or(std::cmp::Ordering::Equal));
+    stats
+}
+
+/// Count of `passed` rows for `test_id` across the entire history.
+/// Used by selector-extraction hooks (Issue #33) and analytics tools.
+pub fn pass_count(test_id: &str) -> usize {
+    let conn = db().lock().unwrap_or_else(|e| e.into_inner());
+    conn.query_row(
+        "SELECT COUNT(*) FROM test_runs WHERE test_id = ?1 AND status = 'passed'",
+        rusqlite::params![test_id],
+        |row| row.get::<_, i64>(0),
+    ).map(|n| n as usize).unwrap_or(0)
+}
+
 pub fn store_knowledge(test_id: &str, key: &str, value: &str) -> Result<(), String> {
     let now = chrono::Local::now().to_rfc3339();
     let conn = db().lock().unwrap_or_else(|e| e.into_inner());
@@ -643,6 +739,44 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(5));
         // 60 min window: should find it
         assert!(has_pending_fix(&tid, 60));
+    }
+
+    #[test]
+    fn test_stats_aggregates() {
+        let tid = format!("test_stats_{}", chrono::Local::now().timestamp_nanos_opt().unwrap_or(0));
+        // 3 passes, 2 fails, mixed → flaky candidate at 60% pass rate
+        insert_many(&tid, &["passed", "failed", "passed", "failed", "passed"]);
+        let stats = test_stats(&tid);
+        assert_eq!(stats.test_id, tid);
+        assert_eq!(stats.total_runs, 5);
+        assert!((stats.pass_rate_7d - 0.6).abs() < 0.01);
+        assert!(stats.is_flaky, "60% pass with mixed outcomes is flaky");
+        // duration_ms == 100 in insert_many → avg ~= 100
+        assert!(stats.avg_duration_ms >= 90 && stats.avg_duration_ms <= 110);
+        assert!(stats.top_failure_category.is_none(),
+            "no failure_category recorded → None");
+    }
+
+    #[test]
+    fn pass_count_counts_only_passed() {
+        let tid = format!("test_pc_{}", chrono::Local::now().timestamp_nanos_opt().unwrap_or(0));
+        insert_many(&tid, &["passed", "failed", "passed", "passed"]);
+        assert_eq!(pass_count(&tid), 3);
+    }
+
+    #[test]
+    fn all_test_stats_sorted_worst_first() {
+        let suffix = chrono::Local::now().timestamp_nanos_opt().unwrap_or(0);
+        let tid_good = format!("zz_good_{suffix}");
+        let tid_bad  = format!("zz_bad_{suffix}");
+        insert_many(&tid_good, &["passed", "passed", "passed"]);
+        insert_many(&tid_bad,  &["failed", "failed", "passed"]);
+        let stats = all_test_stats();
+        let pos_good = stats.iter().position(|s| s.test_id == tid_good);
+        let pos_bad  = stats.iter().position(|s| s.test_id == tid_bad);
+        if let (Some(g), Some(b)) = (pos_good, pos_bad) {
+            assert!(b < g, "worst (bad) must come before best (good): bad={b} good={g}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements Issue #35 — test analytics MCP tool + weekly TG digest scaffolding.

- New MCP tool `test_analytics` returns pass rate (last 10 / 30 runs), flaky flag, avg iterations, avg duration_ms, and top failure_category. Sorted worst-first with summary block (`total_tests` / `flaky_count` / `avg_pass_rate`).
- `store::TestStats` + helpers (`test_stats`, `all_test_stats`, `pass_count`) — pure aggregates on top of existing `test_runs` schema, zero migrations.
- `notify::format_weekly_digest` (pure formatter) + `notify::weekly_test_digest()` (TG send, respects existing `SIRIN_NOTIFY_BOT_TOKEN` / `SIRIN_NOTIFY_CHAT_ID` env vars).
- Cron wiring deferred — no general scheduler framework exists yet in Sirin. Hook `weekly_test_digest()` into any worker / cron-like loop in a follow-up.

## LOC

| File | +Lines |
|------|--------|
| `src/test_runner/store.rs` | +134 (incl. ~37 lines of unit tests) |
| `src/test_runner/notify.rs` | +59 |
| `src/mcp_server.rs` | +42 |
| Total | +235 |

## Test plan

- [x] `cargo check` passes
- [ ] `cargo test --bin sirin store::tests::test_stats_aggregates`
- [ ] `cargo test --bin sirin store::tests::all_test_stats_sorted_worst_first`
- [ ] Manual: `sirin-call.exe test_analytics` returns stats; with `test_id=foo` returns single-test stats.
- [ ] Manual: set `SIRIN_NOTIFY_BOT_TOKEN` / `SIRIN_NOTIFY_CHAT_ID`, call `weekly_test_digest()` from a debug REPL — TG message arrives.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)