### PR TITLE
fix(browser): high DPI click_point 座標縮放

### DIFF
--- a/src/adk/tool/builtins.rs
+++ b/src/adk/tool/builtins.rs
@@ -728,8 +728,17 @@ pub(super) fn build_full_registry() -> ToolRegistry {
                     "click_point" => {
                         let x = input.get("x").and_then(|v| v.as_f64()).ok_or("'click_point' requires 'x'")?;
                         let y = input.get("y").and_then(|v| v.as_f64()).ok_or("'click_point' requires 'y'")?;
-                        browser::click_point(x, y)?;
-                        Ok(json!({ "status": "clicked", "x": x, "y": y }))
+                        // Issue #79: vision LLMs read coords off a screenshot whose
+                        // physical pixel size differs from the CSS viewport on HiDPI
+                        // monitors.  `coord_source="screenshot"` triggers
+                        // devicePixelRatio rescaling; anything else (or absent) is
+                        // treated as raw CSS pixels for backward compatibility.
+                        let source = input.get("coord_source").and_then(|v| v.as_str()).unwrap_or("css");
+                        match source {
+                            "screenshot" => browser::click_point_screenshot(x, y)?,
+                            _ => browser::click_point(x, y)?,
+                        }
+                        Ok(json!({ "status": "clicked", "x": x, "y": y, "coord_source": source }))
                     }
                     "hover" => {
                         if target.is_empty() { return Err("'hover' requires 'target' selector".into()); }
@@ -739,8 +748,12 @@ pub(super) fn build_full_registry() -> ToolRegistry {
                     "hover_point" => {
                         let x = input.get("x").and_then(|v| v.as_f64()).ok_or("'hover_point' requires 'x'")?;
                         let y = input.get("y").and_then(|v| v.as_f64()).ok_or("'hover_point' requires 'y'")?;
-                        browser::hover_point(x, y)?;
-                        Ok(json!({ "status": "hovered", "x": x, "y": y }))
+                        let source = input.get("coord_source").and_then(|v| v.as_str()).unwrap_or("css");
+                        match source {
+                            "screenshot" => browser::hover_point_screenshot(x, y)?,
+                            _ => browser::hover_point(x, y)?,
+                        }
+                        Ok(json!({ "status": "hovered", "x": x, "y": y, "coord_source": source }))
                     }
 
                     // ── Tabs ─────────────────────────────────────────

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1037,8 +1037,66 @@ pub fn install_console_capture() -> Result<(), String> {
 //  TIER 2 — COORDINATE INTERACTION & ELEMENT SCREENSHOT
 // ══════════════════════════════════════════════════════════════════════════════
 
-/// Click at exact viewport coordinates (x, y).  Useful for Canvas-based UIs
-/// (e.g. Flutter Web) where CSS selectors don't work.
+/// Page-coordinate context — relates CSS pixels (the unit CDP expects for
+/// `Input.dispatchMouseEvent`) to the physical pixel size of `screenshot()`'s
+/// PNG output.  On HiDPI / Retina monitors `device_pixel_ratio > 1.0` and the
+/// two coord systems differ by that factor; on a plain 1080p panel they are
+/// equal.  See Issue #79.
+#[derive(Debug, Clone, Copy)]
+pub struct ViewportContext {
+    /// `window.innerWidth` — CSS pixels.
+    pub viewport_width: f64,
+    /// `window.innerHeight` — CSS pixels.
+    pub viewport_height: f64,
+    /// `window.devicePixelRatio` — physical_px / css_px.
+    pub device_pixel_ratio: f64,
+}
+
+impl ViewportContext {
+    /// Convert a screenshot-pixel (physical) coordinate into a CSS-pixel
+    /// coordinate suitable for `Input.dispatchMouseEvent`.
+    pub fn screenshot_to_css(&self, pixel_x: f64, pixel_y: f64) -> (f64, f64) {
+        let dpr = if self.device_pixel_ratio > 0.0 {
+            self.device_pixel_ratio
+        } else {
+            1.0
+        };
+        (pixel_x / dpr, pixel_y / dpr)
+    }
+}
+
+/// Probe the current page for viewport metrics needed to translate
+/// screenshot coordinates → CSS coordinates.  Cheap (single JS eval).
+pub fn viewport_context() -> Result<ViewportContext, String> {
+    let raw = evaluate_js(
+        r#"JSON.stringify({
+            vw:  window.innerWidth,
+            vh:  window.innerHeight,
+            dpr: window.devicePixelRatio || 1
+        })"#,
+    )?;
+    #[derive(serde::Deserialize)]
+    struct Probe {
+        vw: f64,
+        vh: f64,
+        dpr: f64,
+    }
+    let p: Probe = serde_json::from_str(&raw)
+        .map_err(|e| format!("viewport_context parse '{raw}': {e}"))?;
+    Ok(ViewportContext {
+        viewport_width: p.vw,
+        viewport_height: p.vh,
+        device_pixel_ratio: p.dpr,
+    })
+}
+
+/// Click at exact viewport coordinates (x, y) **in CSS pixels**.  Useful for
+/// Canvas-based UIs (e.g. Flutter Web) where CSS selectors don't work.
+///
+/// If your `(x, y)` came from a screenshot pixel position (e.g. a vision LLM
+/// reading the PNG returned by `screenshot()`), use `click_point_screenshot`
+/// instead — on HiDPI monitors the two coord systems differ by
+/// `devicePixelRatio` and this entry point will click the wrong place.
 pub fn click_point(x: f64, y: f64) -> Result<(), String> {
     with_tab(|tab| {
         // Point imported at module level
@@ -1046,6 +1104,19 @@ pub fn click_point(x: f64, y: f64) -> Result<(), String> {
             .map_err(|e| format!("click_point({x},{y}): {e}"))?;
         Ok(())
     })
+}
+
+/// Click at a coordinate read from the screenshot PNG (physical pixels).
+/// Auto-converts to CSS pixels using `window.devicePixelRatio` so the click
+/// hits the same element the vision LLM saw in the image.  See Issue #79.
+pub fn click_point_screenshot(px: f64, py: f64) -> Result<(), String> {
+    let ctx = viewport_context().unwrap_or(ViewportContext {
+        viewport_width: 0.0,
+        viewport_height: 0.0,
+        device_pixel_ratio: 1.0,
+    });
+    let (cx, cy) = ctx.screenshot_to_css(px, py);
+    click_point(cx, cy)
 }
 
 // ── Flutter Shadow DOM helpers ────────────────────────────────────────────────
@@ -1387,7 +1458,8 @@ pub fn flutter_enter() -> Result<String, String> {
     Ok(result)
 }
 
-/// Move the mouse to (x, y) without clicking — triggers hover effects.
+/// Move the mouse to (x, y) **in CSS pixels** without clicking — triggers
+/// hover effects.  See `click_point` for the CSS-vs-screenshot pixel caveat.
 pub fn hover_point(x: f64, y: f64) -> Result<(), String> {
     with_tab(|tab| {
         // Point imported at module level
@@ -1395,6 +1467,18 @@ pub fn hover_point(x: f64, y: f64) -> Result<(), String> {
             .map_err(|e| format!("hover({x},{y}): {e}"))?;
         Ok(())
     })
+}
+
+/// Hover at a coordinate read from the screenshot PNG (physical pixels).
+/// Auto-converts to CSS pixels using `window.devicePixelRatio`.  Issue #79.
+pub fn hover_point_screenshot(px: f64, py: f64) -> Result<(), String> {
+    let ctx = viewport_context().unwrap_or(ViewportContext {
+        viewport_width: 0.0,
+        viewport_height: 0.0,
+        device_pixel_ratio: 1.0,
+    });
+    let (cx, cy) = ctx.screenshot_to_css(px, py);
+    hover_point(cx, cy)
 }
 
 /// Hover over the first element matching a CSS selector.
@@ -2210,6 +2294,44 @@ mod tests {
     use super::*;
 
     // ── Pure unit tests (no Chrome needed) ────────────────────────────────────
+
+    // ── Issue #79: HiDPI screenshot↔CSS pixel conversion ──────────────────────
+
+    #[test]
+    fn viewport_ctx_dpr_2x_screenshot_to_css_halves_coords() {
+        let ctx = ViewportContext {
+            viewport_width: 1920.0,
+            viewport_height: 1080.0,
+            device_pixel_ratio: 2.0,
+        };
+        // A point at the bottom-right of a 2× screenshot (3840 × 2160) maps to
+        // the bottom-right of the 1920 × 1080 CSS viewport.
+        assert_eq!(ctx.screenshot_to_css(3840.0, 2160.0), (1920.0, 1080.0));
+        // Sub-pixel midpoints survive the divide.
+        assert_eq!(ctx.screenshot_to_css(1280.0, 840.0), (640.0, 420.0));
+    }
+
+    #[test]
+    fn viewport_ctx_dpr_1x_is_identity() {
+        let ctx = ViewportContext {
+            viewport_width: 1366.0,
+            viewport_height: 768.0,
+            device_pixel_ratio: 1.0,
+        };
+        assert_eq!(ctx.screenshot_to_css(640.0, 420.0), (640.0, 420.0));
+    }
+
+    #[test]
+    fn viewport_ctx_zero_or_negative_dpr_falls_back_to_1() {
+        // Defensive: a buggy probe returning 0 should not divide-by-zero or
+        // flip the coords — fall back to identity.
+        let ctx = ViewportContext {
+            viewport_width: 100.0,
+            viewport_height: 100.0,
+            device_pixel_ratio: 0.0,
+        };
+        assert_eq!(ctx.screenshot_to_css(50.0, 50.0), (50.0, 50.0));
+    }
 
     #[test]
     fn default_viewport_falls_back_when_env_unset() {

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -552,8 +552,9 @@ fn handle_tools_list() -> Result<Value, String> {
                         "target":             { "type": "string", "description": "URL / CSS selector / JS expr / 文字，視 action 而定。close_session 時為 session_id" },
                         "text":               { "type": "string", "description": "type / ax_type 動作的輸入文字" },
                         "timeout":            { "type": "number", "description": "wait* 動作的 ms timeout（wait_for_url/ax_ready 預設 10000，wait_for_network_idle 預設 15000）" },
-                        "x":                  { "type": "number", "description": "click_point 的 x 座標 (CSS px)" },
-                        "y":                  { "type": "number", "description": "click_point 的 y 座標 (CSS px)" },
+                        "x":                  { "type": "number", "description": "click_point 的 x 座標（單位由 coord_source 決定，預設 CSS px）" },
+                        "y":                  { "type": "number", "description": "click_point 的 y 座標（單位由 coord_source 決定，預設 CSS px）" },
+                        "coord_source":       { "type": "string", "enum": ["css", "screenshot"], "description": "click_point/hover_point 的座標單位：'css'（預設，CDP 直用）或 'screenshot'（截圖物理像素，會自動除以 devicePixelRatio 修正 HiDPI 偏移）" },
                         "width":              { "type": "number", "description": "set_viewport 的 width (px)" },
                         "height":             { "type": "number", "description": "set_viewport 的 height (px)" },
                         "device_scale":       { "type": "number", "description": "set_viewport 的 devicePixelRatio (預設 1.0)" },
@@ -1925,8 +1926,13 @@ async fn call_browser_exec(args: Value, user_agent: &str) -> Result<Value, Strin
             "click_point" => {
                 let cx = x.ok_or("'click_point' requires 'x' (number)")?;
                 let cy = y.ok_or("'click_point' requires 'y' (number)")?;
-                browser::click_point(cx, cy)?;
-                Ok(json!({ "status": "clicked", "x": cx, "y": cy }))
+                // Issue #79: HiDPI screenshot coords need devicePixelRatio rescaling.
+                let source = args.get("coord_source").and_then(Value::as_str).unwrap_or("css");
+                match source {
+                    "screenshot" => browser::click_point_screenshot(cx, cy)?,
+                    _ => browser::click_point(cx, cy)?,
+                }
+                Ok(json!({ "status": "clicked", "x": cx, "y": cy, "coord_source": source }))
             }
             "set_viewport" => {
                 let w = width.ok_or("'set_viewport' requires 'width' (positive integer)")? as u32;

--- a/src/test_runner/executor.rs
+++ b/src/test_runner/executor.rs
@@ -1140,7 +1140,7 @@ fn build_prompt_vision(
 {criteria}
 
 ## Preferred actions (canvas-safe; call via tool "web_navigate", field "action")
-- click_point    — x, y: viewport pixel coords (from the screenshot).  Use this as the default for Flutter / canvas apps.
+- click_point    — x, y: pixel coords read directly off the screenshot PNG.  Use this as the default for Flutter / canvas apps.  ⚠️ HiDPI / Retina screens: ALWAYS pass `"coord_source": "screenshot"` so we divide by devicePixelRatio — without it your click lands at 2× / 4× the wrong place.
 - type           — target: CSS selector (if any), text: text to type.  On canvas pages without selectors, prefer click_point on the input first, then `type` with target omitted.
 - key            — target: key name (Enter / Tab / Escape)
 - scroll         — x, y: pixel deltas (default 0, 300)
@@ -1164,7 +1164,7 @@ definitively failed), set "done": true.
 Respond with STRICTLY valid JSON, no markdown fences, no prose:
 {{
   "thought": "<reasoning in {lang} — cite what you see in the screenshot>",
-  "action_input": {{ "action": "click_point", "x": 640, "y": 420 }},
+  "action_input": {{ "action": "click_point", "x": 640, "y": 420, "coord_source": "screenshot" }},
   "done": false,
   "final_answer": "<only when done=true: summary of outcome in {lang}>"
 }}


### PR DESCRIPTION
Closes #79

## 問題
Vision LLM 從截圖（physical pixels）讀座標傳給 `click_point`，但 CDP `Input.dispatchMouseEvent` 預期的是 **CSS pixels**。在 `devicePixelRatio > 1` 的 HiDPI / Retina 螢幕上，click 落點偏移 DPR 倍率（2× / 4×）；1080p 螢幕剛好兩邊相等，所以這個 bug 在開發機上看不到。

## 修法
最小變動，向後相容：

- **`src/browser.rs`** — 新增 `ViewportContext` struct + `viewport_context()` probe（單次 JS eval 拿 `innerWidth` / `innerHeight` / `devicePixelRatio`）。
- 新增 `click_point_screenshot(px, py)` / `hover_point_screenshot(px, py)` — 物理像素入口，先除以 DPR 再呼叫原本的 CSS-pixel 函式。
- 既有 `click_point` / `hover_point` 維持 CSS-pixel 語意，doc 強化說明。
- **`src/adk/tool/builtins.rs`** + **`src/mcp_server.rs`** — `click_point` / `hover_point` action 收 optional `coord_source` 字串（`"css"` | `"screenshot"`）。`"css"` 為預設值，既有 YAML / MCP 呼叫零行為改變。
- **`src/test_runner/executor.rs`** — vision prompt 加 HiDPI 警示，example JSON 改成 `"coord_source": "screenshot"` 引導 LLM 用對單位。

## 驗證
- `cargo check`: 0 error（新增 154 行，刪除 13 行）
- 新 unit test（`src/browser.rs` tests mod）：
  - `viewport_ctx_dpr_2x_screenshot_to_css_halves_coords` — 4K 截圖 (3840, 2160) → (1920, 1080) CSS
  - `viewport_ctx_dpr_1x_is_identity` — 1080p 螢幕零變動
  - `viewport_ctx_zero_or_negative_dpr_falls_back_to_1` — 防呆
  - ⚠️ `cargo test --bin sirin` 因 `src/test_runner/runs.rs` 的 pre-existing TestStep 欄位不齊而無法 link（與本 PR 無關，最近 commit 96569f6 後就壞了）；本 PR 不修這個。
- 無 E2E 測試（需要實機 Retina / 4K 環境）

## 改動範圍
| 檔案 | 變動 |
|------|------|
| `src/browser.rs` | +120 / -2（新 struct、probe、screenshot wrappers、3 unit tests） |
| `src/adk/tool/builtins.rs` | +18 / -3 |
| `src/mcp_server.rs` | +9 / -3 |
| `src/test_runner/executor.rs` | +2 / -2 |