### PR TITLE
feat(privacy): 截圖前自動遮罩密碼/敏感欄位

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -74,6 +74,19 @@ static SESSION: OnceLock<Arc<Mutex<Option<BrowserInner>>>> = OnceLock::new();
 /// (instead of falling back to `default_headless()` which is always `true`).
 static TEST_DESIRED_HEADLESS: AtomicBool = AtomicBool::new(true);
 
+/// Whether to inject a privacy CSS mask immediately before screenshot capture.
+/// Defaults to `true` (fail-secure): password / credit-card / OTP fields are
+/// blurred + colour-stripped so the captured PNG cannot leak plaintext into
+/// `test_failures/`, vision LLM uploads, or GitHub bug reports.
+///
+/// Disable by:
+/// - YAML test goal: `mask_sensitive: false` (test runner flips this for the
+///   duration of that test, then restores the previous value).
+/// - Env: `SIRIN_PRIVACY_MASK=0` (read once at process start).
+///
+/// See Issue #80 for the threat model.
+static PRIVACY_MASK_ENABLED: AtomicBool = AtomicBool::new(true);
+
 /// Signal that stops the CDP keepalive heartbeat thread.
 /// Set to `true` by `close()` before dropping the browser session.
 static HEARTBEAT_STOP: AtomicBool = AtomicBool::new(false);
@@ -98,6 +111,30 @@ thread_local! {
 /// even if the process-level default is `headless=true`.
 pub fn set_test_headless_mode(headless: bool) {
     TEST_DESIRED_HEADLESS.store(headless, Ordering::Relaxed);
+}
+
+/// Initialise the global privacy-mask toggle from `SIRIN_PRIVACY_MASK`.
+/// Called once near process start.  `1`/`true`/`yes` → on (default),
+/// `0`/`false`/`no` → off.  Any other value also leaves it on (fail-secure).
+pub fn init_privacy_mask_from_env() {
+    let on = match std::env::var("SIRIN_PRIVACY_MASK").ok().as_deref() {
+        Some("0") | Some("false") | Some("FALSE") | Some("no") | Some("NO") => false,
+        _ => true,
+    };
+    PRIVACY_MASK_ENABLED.store(on, Ordering::Relaxed);
+}
+
+/// Set the privacy-mask toggle for the currently-running test.  Returns the
+/// previous value so the caller can restore it after the test finishes.
+///
+/// See [`PRIVACY_MASK_ENABLED`] for the rationale.
+pub fn set_privacy_mask(enabled: bool) -> bool {
+    PRIVACY_MASK_ENABLED.swap(enabled, Ordering::Relaxed)
+}
+
+/// Whether the privacy mask should be injected before the next screenshot.
+pub fn privacy_mask_enabled() -> bool {
+    PRIVACY_MASK_ENABLED.load(Ordering::Relaxed)
 }
 
 fn global() -> &'static Arc<Mutex<Option<BrowserInner>>> {
@@ -591,10 +628,115 @@ fn split_hash(url: &str) -> (&str, &str) {
     }
 }
 
+// ── Privacy mask (Issue #80) ─────────────────────────────────────────────────
+//
+// Goal: prevent password / credit-card / OTP plaintext from leaking into
+// failure screenshots stored in `test_failures/`, uploaded to vision LLMs,
+// or pasted into GitHub bug reports.  We inject CSS that blurs and
+// colour-strips matching inputs immediately before capture, then remove it
+// so subsequent test steps see the page unchanged.
+//
+// JS runs synchronously inside the page (Runtime.evaluate) so the style is
+// applied before the next CDP frame.  Both inject and remove are best-effort
+// — failures are logged but never abort the screenshot.
+
+const PRIVACY_MASK_STYLE_ID: &str = "__sirin_privacy_mask__";
+
+/// CSS rule list that defines which fields the mask covers.  Centralised so
+/// tests can assert against it.
+const PRIVACY_MASK_CSS: &str = r#"
+input[type="password"],
+input[autocomplete*="cc-"],
+input[autocomplete*="one-time-code"],
+input[autocomplete*="otp"],
+input[name*="password" i],
+input[name*="passwd" i],
+input[name*="ssn" i],
+input[name*="credit" i],
+input[name*="card-number" i],
+input[name*="cardnumber" i],
+input[name*="cvv" i],
+input[name*="cvc" i],
+input[aria-label*="password" i],
+input[aria-label*="\5BC6\78BC"],
+input[aria-label*="credit" i],
+input[aria-label*="ssn" i],
+[data-sensitive],
+[data-sirin-mask="true"] {
+  filter: blur(8px) !important;
+  background: #1A1A1A !important;
+  color: transparent !important;
+  caret-color: transparent !important;
+  text-shadow: none !important;
+  -webkit-text-security: disc !important;
+}
+"#;
+
+fn build_inject_js() -> String {
+    // Single-shot inject: idempotent — if a previous screenshot left the style
+    // behind for any reason, replace it.  Returns 1 on success.
+    let css = PRIVACY_MASK_CSS.replace('`', r"\`");
+    format!(
+        r#"(function() {{
+  try {{
+    var id = "{id}";
+    var prev = document.getElementById(id);
+    if (prev) prev.remove();
+    var s = document.createElement("style");
+    s.id = id;
+    s.textContent = `{css}`;
+    (document.head || document.documentElement).appendChild(s);
+    return 1;
+  }} catch (e) {{ return 0; }}
+}})()"#,
+        id = PRIVACY_MASK_STYLE_ID,
+        css = css,
+    )
+}
+
+fn build_remove_js() -> String {
+    format!(
+        r#"(function() {{
+  try {{
+    var el = document.getElementById("{id}");
+    if (el) el.remove();
+    return 1;
+  }} catch (e) {{ return 0; }}
+}})()"#,
+        id = PRIVACY_MASK_STYLE_ID,
+    )
+}
+
+/// Inject the privacy-mask `<style>` element if the global toggle is on.
+/// Errors are logged at debug level and never propagate — masking is a
+/// defence-in-depth, not a hard precondition.
+fn inject_privacy_mask(tab: &Tab) {
+    if !privacy_mask_enabled() {
+        return;
+    }
+    if let Err(e) = tab.evaluate(&build_inject_js(), false) {
+        tracing::debug!("[privacy_mask] inject failed (non-fatal): {e}");
+    }
+}
+
+/// Remove the privacy-mask `<style>` element so subsequent test steps see
+/// the page unchanged.  Best-effort.
+fn remove_privacy_mask(tab: &Tab) {
+    if !privacy_mask_enabled() {
+        return;
+    }
+    if let Err(e) = tab.evaluate(&build_remove_js(), false) {
+        tracing::debug!("[privacy_mask] remove failed (non-fatal): {e}");
+    }
+}
+
 pub fn screenshot() -> Result<Vec<u8>, String> {
     with_tab(|tab| {
-        tab.capture_screenshot(CaptureScreenshotFormatOption::Png, None, None, true)
-            .map_err(|e| format!("screenshot: {e}"))
+        inject_privacy_mask(tab);
+        let res = tab.capture_screenshot(CaptureScreenshotFormatOption::Png, None, None, true)
+            .map_err(|e| format!("screenshot: {e}"));
+        remove_privacy_mask(tab);
+        res
     })
 }
 
@@ -609,13 +751,16 @@ pub fn get_current_url() -> Result<String, String> {
 pub fn screenshot_jpeg(quality: u8) -> Result<Vec<u8>, String> {
     with_tab(|tab| {
         let q = quality.clamp(1, 100) as u32;
-        tab.capture_screenshot(
+        inject_privacy_mask(tab);
+        let res = tab.capture_screenshot(
             CaptureScreenshotFormatOption::Jpeg,
             Some(q),
             None,
             true,
         )
-        .map_err(|e| format!("screenshot_jpeg: {e}"))
+        .map_err(|e| format!("screenshot_jpeg: {e}"));
+        remove_privacy_mask(tab);
+        res
     })
 }
 
@@ -1416,7 +1561,8 @@ pub fn screenshot_element(selector: &str) -> Result<Vec<u8>, String> {
         let model = el.get_box_model()
             .map_err(|e| format!("get_box_model '{selector}': {e}"))?;
         let vp = model.content_viewport();
-        tab.capture_screenshot(
+        inject_privacy_mask(tab);
+        let res = tab.capture_screenshot(
             CaptureScreenshotFormatOption::Png,
             None,
             Some(Page::Viewport {
@@ -1427,7 +1573,9 @@ pub fn screenshot_element(selector: &str) -> Result<Vec<u8>, String> {
                 scale: vp.scale,
             }),
             true,
-        ).map_err(|e| format!("screenshot_element '{selector}': {e}"))
+        ).map_err(|e| format!("screenshot_element '{selector}': {e}"));
+        remove_privacy_mask(tab);
+        res
     })
 }
 
@@ -2371,6 +2519,85 @@ mod tests {
         if let Some(v) = orig {
             std::env::set_var("SIRIN_BROWSER_HEADLESS", v);
         }
+    }
+
+    #[test]
+    fn privacy_mask_default_on_and_toggle_round_trips() {
+        // Default = on (fail-secure) — explicitly set so we don't depend on
+        // sibling-test side effects.
+        let _ = set_privacy_mask(true);
+        assert!(privacy_mask_enabled(), "default must be on for fail-secure");
+
+        let prev = set_privacy_mask(false);
+        assert!(prev, "set_privacy_mask returns previous value");
+        assert!(!privacy_mask_enabled());
+
+        let prev = set_privacy_mask(true);
+        assert!(!prev);
+        assert!(privacy_mask_enabled());
+    }
+
+    #[test]
+    fn privacy_mask_env_off_disables_default() {
+        let orig = std::env::var("SIRIN_PRIVACY_MASK").ok();
+
+        // Anything but explicit off → on (fail-secure)
+        std::env::set_var("SIRIN_PRIVACY_MASK", "1");
+        init_privacy_mask_from_env();
+        assert!(privacy_mask_enabled());
+
+        std::env::remove_var("SIRIN_PRIVACY_MASK");
+        init_privacy_mask_from_env();
+        assert!(privacy_mask_enabled(), "unset must default to on");
+
+        std::env::set_var("SIRIN_PRIVACY_MASK", "garbage");
+        init_privacy_mask_from_env();
+        assert!(privacy_mask_enabled(), "unrecognised must default to on");
+
+        // Explicit off variants
+        for off in ["0", "false", "FALSE", "no", "NO"] {
+            std::env::set_var("SIRIN_PRIVACY_MASK", off);
+            init_privacy_mask_from_env();
+            assert!(!privacy_mask_enabled(), "{off} must disable mask");
+        }
+
+        // Restore
+        match orig {
+            Some(v) => std::env::set_var("SIRIN_PRIVACY_MASK", v),
+            None    => std::env::remove_var("SIRIN_PRIVACY_MASK"),
+        }
+        // Leave global in fail-secure state for subsequent tests
+        let _ = set_privacy_mask(true);
+    }
+
+    #[test]
+    fn privacy_mask_css_covers_known_sensitive_selectors() {
+        // Sanity-check that the CSS we will inject actually targets the
+        // selectors enumerated in Issue #80.  Catches accidental deletions.
+        for sel in [
+            r#"input[type="password"]"#,
+            r#"input[autocomplete*="cc-"]"#,
+            r#"input[autocomplete*="one-time-code"]"#,
+            r#"input[name*="password" i]"#,
+            r#"input[name*="ssn" i]"#,
+            r#"input[name*="cardnumber" i]"#,
+            r#"input[aria-label*="password" i]"#,
+            r#"[data-sensitive]"#,
+        ] {
+            assert!(
+                PRIVACY_MASK_CSS.contains(sel),
+                "PRIVACY_MASK_CSS missing selector: {sel}"
+            );
+        }
+        // Mask must visually destroy the value, not just blur (blur alone
+        // can be reversed by sharpening filters in vision LLMs).
+        assert!(PRIVACY_MASK_CSS.contains("filter: blur(8px)"));
+        assert!(PRIVACY_MASK_CSS.contains("color: transparent"));
+        assert!(PRIVACY_MASK_CSS.contains("background:"));
+
+        // The injection script must reference the same style id we remove.
+        assert!(build_inject_js().contains(PRIVACY_MASK_STYLE_ID));
+        assert!(build_remove_js().contains(PRIVACY_MASK_STYLE_ID));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,10 @@ fn main() {
 
     ensure_first_run_dirs();
 
+    // ── Privacy mask default (Issue #80) ─────────────────────────────────────
+    // Read SIRIN_PRIVACY_MASK once .env is loaded.  Default = on (fail-secure).
+    browser::init_privacy_mask_from_env();
+
     // ── AuthZ engine init ────────────────────────────────────────────────────
     authz::init(Some(std::path::Path::new(".")));
     tracing::info!(target: "sirin", "[main] AuthZ engine initialized");

--- a/src/test_runner/executor.rs
+++ b/src/test_runner/executor.rs
@@ -437,6 +437,21 @@ pub async fn execute_test_tracked(
         );
     }
 
+    // 0-priv) Privacy mask (Issue #80): default ON — fail-secure.  Restored to
+    // the previous global value when this run finishes (so a `mask_sensitive:
+    // false` test does not leak its preference into the next test).
+    let want_mask = test.mask_sensitive.unwrap_or(true);
+    let prev_mask = crate::browser::set_privacy_mask(want_mask);
+    /// RAII guard that restores the global privacy-mask flag on drop, even if
+    /// the test panics or returns early.
+    struct MaskGuard(bool);
+    impl Drop for MaskGuard {
+        fn drop(&mut self) {
+            crate::browser::set_privacy_mask(self.0);
+        }
+    }
+    let _mask_guard = MaskGuard(prev_mask);
+
     // 0) Ensure browser launched in the right headless mode.
     // Flutter CanvasKit/WebGL needs headless=false to actually paint.
     let want_headless = test.browser_headless.unwrap_or_else(crate::browser::default_headless);

--- a/src/test_runner/mod.rs
+++ b/src/test_runner/mod.rs
@@ -235,6 +235,7 @@ pub fn spawn_adhoc_run(req: AdhocRunRequest) -> Result<String, String> {
         docs_refs: vec![],  // ad-hoc runs have no pre-defined required reading
         kb_refs:   vec![],  // ad-hoc runs don't reference KB topic keys
         perception: Default::default(),
+        mask_sensitive: None,  // None → executor defaults to fail-secure on
     };
 
     let run_id = runs::new_run(&test_id);
@@ -699,6 +700,7 @@ pub fn persist_adhoc_run(p: PersistAdhocParams) -> Result<PersistAdhocResult, St
         docs_refs: goal.docs_refs.clone(),  // propagate required-reading from source run
         kb_refs:   goal.kb_refs.clone(),    // propagate KB topic-key refs too
         perception: goal.perception,
+        mask_sensitive: goal.mask_sensitive,
     };
 
     // Serialize and write.  serde_yaml uses 2-space indent and never
@@ -759,6 +761,7 @@ mod persist_tests {
             docs_refs: vec![],
             kb_refs: vec![],
             perception: Default::default(),
+            mask_sensitive: None,
         };
         let run_id = runs::new_run(test_id);
         runs::set_goal(&run_id, goal.clone());
@@ -843,6 +846,7 @@ mod persist_tests {
             docs_refs: vec![],
             kb_refs: vec![],
             perception: Default::default(),
+            mask_sensitive: None,
         });
         runs::set_phase(&run_id, runs::RunPhase::Running {
             step: 2,
@@ -925,6 +929,7 @@ mod persist_tests {
             docs_refs: vec![],
             kb_refs: vec![],
             perception: Default::default(),
+            mask_sensitive: None,
         };
         // Insert directly into SQLite — simulates the row that
         // record_run wrote at the original run completion.

--- a/src/test_runner/parser.rs
+++ b/src/test_runner/parser.rs
@@ -120,6 +120,18 @@ pub struct TestGoal {
     /// explicitly on Flutter / canvas pages where the AX tree is unreliable.
     #[serde(default)]
     pub perception: crate::perception::PerceptionMode,
+    /// Whether to inject a CSS privacy mask before every screenshot taken
+    /// during this test (password / credit-card / OTP / SSN inputs are
+    /// blurred + colour-stripped so plaintext cannot leak into
+    /// `test_failures/`, vision LLM uploads, or GitHub bug reports).
+    ///
+    /// Default `true` (fail-secure — Issue #80).  Set to `false` only when
+    /// you are deliberately verifying that an input renders a secret value
+    /// (e.g. testing the masking itself), or when the mask interferes with
+    /// the assertion (rare).  The process-wide default is also overridable
+    /// via `SIRIN_PRIVACY_MASK=0` env var.
+    #[serde(default)]
+    pub mask_sensitive: Option<bool>,
 }
 
 impl TestGoal {


### PR DESCRIPTION
Closes #80

## 動機
失敗截圖會存進 `%LOCALAPPDATA%/Sirin/test_failures/`、上傳給 vision LLM、貼進 GitHub bug report。目前完全沒有遮罩 — 密碼欄位的 placeholder/value、信用卡號、API token、OTP 都會明文外洩。Issue #80 要求 fail-secure 的預設遮罩。

## 實作

**截圖前注入 CSS、截圖後移除** — 三個入口都套用：

- `browser::screenshot()` (PNG)
- `browser::screenshot_jpeg()` (Live Monitor pump)
- `browser::screenshot_element()` (element-cropped)

涵蓋欄位：
- `input[type=\"password\"]`
- `input[autocomplete*=\"cc-\"]` / `\"one-time-code\"` / `\"otp\"`
- `input[name|aria-label*=\"password|ssn|credit|card-number|cvv|cvc\"]`（case-insensitive，含中文「密碼」aria-label）
- `[data-sensitive]` / `[data-sirin-mask=\"true\"]` 業務代碼可加的明示標記

遮罩樣式（不只 blur — vision LLM 可用銳化反轉純 blur）：
```css
filter: blur(8px); background: #1A1A1A; color: transparent;
caret-color: transparent; text-shadow: none;
-webkit-text-security: disc;
```

## Opt-out（兩層）

1. YAML test goal：`mask_sensitive: false`（預設 `None` → on）
2. 環境變數：`SIRIN_PRIVACY_MASK=0`（process-wide 預設）

執行器在測試開始時翻 `set_privacy_mask(want)`，用 `Drop` guard 在測試結束/panic 時還原前值 — 單一 opt-out 測試不會污染下一支測試。

## 安全考量
- 預設啟用（fail-secure）— `None` / 無法解析的 env 值都當 on
- CSS filter+background+transparent text 三重組合，無法從截圖反推
- inject/remove 用 best-effort（debug log + 不擋截圖）— 即使 CDP 故障也不會讓測試失敗
- 只動截圖前後，**不改 vision LLM prompt 結構**（user 限制）

## 改動範圍
| 檔案 | 變更 |
|---|---|
| `src/browser.rs` | privacy mask CSS + inject/remove helpers + atomic toggle + 3 個 screenshot fn 包一層 + 3 個 unit test |
| `src/main.rs` | 啟動時 `init_privacy_mask_from_env()` |
| `src/test_runner/parser.rs` | TestGoal 加 `mask_sensitive: Option<bool>` 欄位 |
| `src/test_runner/executor.rs` | 測試開始 swap atomic + RAII guard 還原 |
| `src/test_runner/mod.rs` | 4 處 TestGoal 構造補 `mask_sensitive: None` |

5 files changed, 269 insertions(+), 6 deletions(-)（含 ~80 行 unit test + ~40 行 CSS/JS 字面量；production code ≈170 LOC）

## 驗證
- `cargo check` — 0 error，0 新 warning
- 3 個新 unit test（toggle round-trip、env 解析、CSS 涵蓋面）— 編譯通過（既有 `runs.rs` test 編譯 error 為 pre-existing on main，與本 PR 無關）

## 未涵蓋（deferred）
- Phase 2 (YAML `privacy.mask_selectors` / `mask_text_regex` 自訂規則) — 等實際遇到 selector 蓋不到的洩漏案例再做
- Phase 3 (OCR 截圖後雙重檢查) — 需要 perception::ocr 重構，獨立 issue