### PR TITLE
feat(browser): 頁面內 action 指示器 + HIDE_FOR_TOOL_USE 屬性

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -730,11 +730,212 @@ fn remove_privacy_mask(tab: &Tab) {
     }
 }
 
+// ── Action indicator + HIDE_FOR_TOOL_USE (Issue #75) ────────────────────────
+//
+// When `ACTION_INDICATOR_ENABLED` is on, the test executor injects a small
+// in-page DOM overlay (right-bottom badge + faint border) so the user can SEE
+// that Sirin is driving the page.  The badge text updates as the LLM picks
+// each next action.
+//
+// Two orthogonal hide paths run before every screenshot / AX-tree read:
+//
+//   1. The indicator itself — Sirin's own UI must never appear in failure
+//      screenshots or pollute the AX-tree observation we feed back to the LLM.
+//   2. `HIDE_FOR_TOOL_USE`: any element a *test author* tags with
+//      `data-sirin-hide` (or the CiC-compatible alias `data-claude-hide`) gets
+//      `visibility:hidden` while the agent observes.  Useful for blanking out
+//      a banner or ad while the agent is asserting page correctness, and as a
+//      lightweight prompt-injection mitigation for content the page itself
+//      wants the agent to ignore.
+//
+// IMPORTANT — this is **UX, not a security boundary**.  The agent can still
+// read the source DOM via `eval` to bypass it.  The contract is "don't show
+// this to the LLM in its default observation channels (AX tree / screenshot)".
+//
+// Ordering vs privacy mask (Issue #80): both inject distinct `<style>` nodes
+// keyed by different IDs and both remove themselves after capture, so they
+// compose cleanly — no inject/remove interlock required.
+
+const ACTION_INDICATOR_BORDER_ID: &str = "__sirin_indicator_border__";
+const ACTION_INDICATOR_BADGE_ID:  &str = "__sirin_indicator_badge__";
+const ACTION_INDICATOR_STYLE_ID:  &str = "__sirin_indicator_style__";
+const HIDE_FOR_TOOL_USE_STYLE_ID: &str = "__sirin_hide_for_tool_use__";
+
+/// CSS that hides any element annotated with `data-sirin-hide` or
+/// `data-claude-hide` while a tool is observing the page.  Also hides
+/// the action indicator itself so it never lands in screenshots.
+const HIDE_FOR_TOOL_USE_CSS: &str = r#"
+[data-sirin-hide], [data-claude-hide],
+#__sirin_indicator_border__,
+#__sirin_indicator_badge__ {
+  visibility: hidden !important;
+}
+"#;
+
+/// Process-wide enable for the action indicator.  Off by default so headless
+/// CI runs and any caller that hasn't opted in keeps a clean DOM.  Flipped on
+/// by the test executor for runs with `show_action_indicator: true`.
+static ACTION_INDICATOR_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Toggle the in-page action indicator.  Returns the previous value so the
+/// caller can restore it after a test finishes (mirrors `set_privacy_mask`).
+pub fn set_action_indicator(enabled: bool) -> bool {
+    ACTION_INDICATOR_ENABLED.swap(enabled, Ordering::Relaxed)
+}
+
+/// Whether the action indicator is currently enabled.
+pub fn action_indicator_enabled() -> bool {
+    ACTION_INDICATOR_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Build the JS that injects (or refreshes) the in-page indicator.  Called
+/// at test start and re-called on each action to update the badge text.
+fn build_indicator_inject_js(action: &str) -> String {
+    // Escape backticks + backslashes so the action text can never break out
+    // of the template literal.  Truncate to keep the badge readable.
+    let truncated: String = action.chars().take(60).collect();
+    let safe = truncated.replace('\\', r"\\").replace('`', r"\`");
+    format!(
+        r#"(function() {{
+  try {{
+    var BORDER_ID = "{border}";
+    var BADGE_ID  = "{badge}";
+    var STYLE_ID  = "{style}";
+    var label = `Sirin: ${{`{safe}`}}`;
+    if (!document.getElementById(STYLE_ID)) {{
+      var s = document.createElement("style");
+      s.id = STYLE_ID;
+      s.textContent = "@keyframes __sirin_pulse{{0%,100%{{box-shadow:0 0 12px #00FFA3,inset 0 0 12px rgba(0,255,163,.1)}}50%{{box-shadow:0 0 24px #00FFA3,inset 0 0 20px rgba(0,255,163,.2)}}}}";
+      (document.head || document.documentElement).appendChild(s);
+    }}
+    var border = document.getElementById(BORDER_ID);
+    if (!border) {{
+      border = document.createElement("div");
+      border.id = BORDER_ID;
+      border.setAttribute("aria-hidden", "true");
+      border.style.cssText = "position:fixed;inset:0;pointer-events:none;border:2px solid #00FFA3;border-radius:2px;z-index:2147483646;box-shadow:0 0 12px #00FFA3,inset 0 0 12px rgba(0,255,163,.1);animation:__sirin_pulse 2s ease-in-out infinite;";
+      document.body.appendChild(border);
+    }}
+    var badge = document.getElementById(BADGE_ID);
+    if (!badge) {{
+      badge = document.createElement("div");
+      badge.id = BADGE_ID;
+      badge.setAttribute("aria-hidden", "true");
+      badge.style.cssText = "position:fixed;bottom:16px;right:16px;z-index:2147483647;padding:6px 12px;background:#1A1A1A;color:#00FFA3;border:1px solid #333;border-radius:4px;font-family:monospace;font-size:12px;pointer-events:none;max-width:60vw;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;";
+      document.body.appendChild(badge);
+    }}
+    badge.textContent = label;
+    return 1;
+  }} catch (e) {{ return 0; }}
+}})()"#,
+        border = ACTION_INDICATOR_BORDER_ID,
+        badge  = ACTION_INDICATOR_BADGE_ID,
+        style  = ACTION_INDICATOR_STYLE_ID,
+        safe   = safe,
+    )
+}
+
+/// Build the JS that removes the indicator + style.  Idempotent.
+fn build_indicator_remove_js() -> String {
+    format!(
+        r#"(function() {{
+  try {{
+    ["{border}", "{badge}", "{style}"].forEach(function(id) {{
+      var el = document.getElementById(id);
+      if (el) el.remove();
+    }});
+    return 1;
+  }} catch (e) {{ return 0; }}
+}})()"#,
+        border = ACTION_INDICATOR_BORDER_ID,
+        badge  = ACTION_INDICATOR_BADGE_ID,
+        style  = ACTION_INDICATOR_STYLE_ID,
+    )
+}
+
+/// Inject (or refresh) the action indicator with the given action label.
+/// No-op if [`action_indicator_enabled`] is `false`.  Failures are demoted
+/// to debug log — never propagate.
+pub fn show_action_indicator(action: &str) {
+    if !action_indicator_enabled() {
+        return;
+    }
+    let js = build_indicator_inject_js(action);
+    let _ = with_tab(|tab| {
+        if let Err(e) = tab.evaluate(&js, false) {
+            tracing::debug!("[indicator] inject failed (non-fatal): {e}");
+        }
+        Ok(())
+    });
+}
+
+/// Remove the action indicator immediately.  Use at end-of-test cleanup.
+/// Best-effort.
+pub fn hide_action_indicator() {
+    let js = build_indicator_remove_js();
+    let _ = with_tab(|tab| {
+        if let Err(e) = tab.evaluate(&js, false) {
+            tracing::debug!("[indicator] remove failed (non-fatal): {e}");
+        }
+        Ok(())
+    });
+}
+
+fn build_hide_for_tool_use_inject_js() -> String {
+    let css = HIDE_FOR_TOOL_USE_CSS.replace('`', r"\`");
+    format!(
+        r#"(function() {{
+  try {{
+    var id = "{id}";
+    var prev = document.getElementById(id);
+    if (prev) prev.remove();
+    var s = document.createElement("style");
+    s.id = id;
+    s.textContent = `{css}`;
+    (document.head || document.documentElement).appendChild(s);
+    return 1;
+  }} catch (e) {{ return 0; }}
+}})()"#,
+        id  = HIDE_FOR_TOOL_USE_STYLE_ID,
+        css = css,
+    )
+}
+
+fn build_hide_for_tool_use_remove_js() -> String {
+    format!(
+        r#"(function() {{
+  try {{
+    var el = document.getElementById("{id}");
+    if (el) el.remove();
+    return 1;
+  }} catch (e) {{ return 0; }}
+}})()"#,
+        id = HIDE_FOR_TOOL_USE_STYLE_ID,
+    )
+}
+
+/// Inject HIDE_FOR_TOOL_USE CSS — hides Sirin's own indicator AND any
+/// element tagged `data-sirin-hide` / `data-claude-hide`.  Always runs
+/// before screenshot; cheap (single style insert).
+fn inject_hide_for_tool_use(tab: &Tab) {
+    if let Err(e) = tab.evaluate(&build_hide_for_tool_use_inject_js(), false) {
+        tracing::debug!("[hide_for_tool_use] inject failed (non-fatal): {e}");
+    }
+}
+
+fn remove_hide_for_tool_use(tab: &Tab) {
+    if let Err(e) = tab.evaluate(&build_hide_for_tool_use_remove_js(), false) {
+        tracing::debug!("[hide_for_tool_use] remove failed (non-fatal): {e}");
+    }
+}
+
 pub fn screenshot() -> Result<Vec<u8>, String> {
     with_tab(|tab| {
         inject_privacy_mask(tab);
+        inject_hide_for_tool_use(tab);
         let res = tab.capture_screenshot(CaptureScreenshotFormatOption::Png, None, None, true)
             .map_err(|e| format!("screenshot: {e}"));
+        remove_hide_for_tool_use(tab);
         remove_privacy_mask(tab);
         res
     })
@@ -752,6 +953,7 @@ pub fn screenshot_jpeg(quality: u8) -> Result<Vec<u8>, String> {
     with_tab(|tab| {
         let q = quality.clamp(1, 100) as u32;
         inject_privacy_mask(tab);
+        inject_hide_for_tool_use(tab);
         let res = tab.capture_screenshot(
             CaptureScreenshotFormatOption::Jpeg,
             Some(q),
@@ -759,6 +961,7 @@ pub fn screenshot_jpeg(quality: u8) -> Result<Vec<u8>, String> {
             true,
         )
         .map_err(|e| format!("screenshot_jpeg: {e}"));
+        remove_hide_for_tool_use(tab);
         remove_privacy_mask(tab);
         res
     })
@@ -1646,6 +1849,7 @@ pub fn screenshot_element(selector: &str) -> Result<Vec<u8>, String> {
             .map_err(|e| format!("get_box_model '{selector}': {e}"))?;
         let vp = model.content_viewport();
         inject_privacy_mask(tab);
+        inject_hide_for_tool_use(tab);
         let res = tab.capture_screenshot(
             CaptureScreenshotFormatOption::Png,
             None,
@@ -1658,6 +1862,7 @@ pub fn screenshot_element(selector: &str) -> Result<Vec<u8>, String> {
             }),
             true,
         ).map_err(|e| format!("screenshot_element '{selector}': {e}"));
+        remove_hide_for_tool_use(tab);
         remove_privacy_mask(tab);
         res
     })
@@ -2690,6 +2895,54 @@ mod tests {
         }
         // Leave global in fail-secure state for subsequent tests
         let _ = set_privacy_mask(true);
+    }
+
+    #[test]
+    fn action_indicator_toggle_round_trips() {
+        // Default = off (CI safety).
+        let _ = set_action_indicator(false);
+        assert!(!action_indicator_enabled(), "default must be off");
+
+        let prev = set_action_indicator(true);
+        assert!(!prev, "set_action_indicator returns previous value");
+        assert!(action_indicator_enabled());
+
+        let prev = set_action_indicator(false);
+        assert!(prev);
+        assert!(!action_indicator_enabled());
+    }
+
+    #[test]
+    fn action_indicator_inject_js_escapes_action_label() {
+        // Backticks and backslashes in action labels must not break out of
+        // the JS template literal.  We simply check the produced JS contains
+        // the escaped form rather than the raw form.
+        let js = build_indicator_inject_js("click `evil` \\path");
+        assert!(js.contains(r"\`evil\`"), "backticks must be escaped: {js}");
+        assert!(js.contains(r"\\path"), "backslashes must be escaped: {js}");
+        // Stable IDs present so AX/screenshot filter can match them
+        assert!(js.contains(ACTION_INDICATOR_BORDER_ID));
+        assert!(js.contains(ACTION_INDICATOR_BADGE_ID));
+    }
+
+    #[test]
+    fn hide_for_tool_use_css_hides_indicator_and_data_attrs() {
+        // Sanity-check that the hide CSS actually targets:
+        //   1. The indicator border + badge (Sirin's own UI).
+        //   2. Both `data-sirin-hide` and the CiC-compatible `data-claude-hide`.
+        for needle in [
+            "data-sirin-hide",
+            "data-claude-hide",
+            ACTION_INDICATOR_BORDER_ID,
+            ACTION_INDICATOR_BADGE_ID,
+            "visibility: hidden",
+        ] {
+            assert!(
+                HIDE_FOR_TOOL_USE_CSS.contains(needle),
+                "hide CSS missing '{needle}': {}",
+                HIDE_FOR_TOOL_USE_CSS
+            );
+        }
     }
 
     #[test]

--- a/src/browser_ax.rs
+++ b/src/browser_ax.rs
@@ -201,6 +201,12 @@ pub fn get_full_tree(include_ignored: bool) -> Result<Vec<AxNode>, String> {
     let nodes = raw.get("nodes").and_then(|v| v.as_array())
         .ok_or_else(|| format!("getFullAXTree: missing nodes array; got {raw}"))?;
 
+    // HIDE_FOR_TOOL_USE (Issue #75): drop nodes whose DOM element bears
+    // `data-sirin-hide` / `data-claude-hide`, plus Sirin's own action
+    // indicator badge/border.  Fail-open — an empty set on JS error means
+    // we observe the page exactly as we did before this filter existed.
+    let hidden = collect_hidden_backend_ids().unwrap_or_default();
+
     let mut out = Vec::with_capacity(nodes.len());
     for n in nodes {
         let role = json_ax_value(n, "role");
@@ -212,6 +218,11 @@ pub fn get_full_tree(include_ignored: bool) -> Result<Vec<AxNode>, String> {
             }
         }
         let backend_id = n.get("backendDOMNodeId").and_then(|v| v.as_u64()).map(|n| n as u32);
+        if let Some(bid) = backend_id {
+            if hidden.contains(&bid) {
+                continue;
+            }
+        }
         let child_ids = n.get("childIds").and_then(|v| v.as_array())
             .map(|a| a.iter().filter_map(|x| x.as_str().map(String::from)).collect())
             .unwrap_or_default();
@@ -227,6 +238,61 @@ pub fn get_full_tree(include_ignored: bool) -> Result<Vec<AxNode>, String> {
         });
     }
     Ok(out)
+}
+
+/// Collect backend node IDs of every DOM element marked with
+/// `data-sirin-hide` / `data-claude-hide`, plus Sirin's own action-indicator
+/// elements.  Used to filter the AX tree so the LLM never observes them.
+///
+/// Implementation: a single `Runtime.evaluate` walks the DOM and returns
+/// an array.  We then call `DOM.requestNode` per matched element to map
+/// each node to a backend id.  Errors degrade silently — the AX-tree path
+/// must never break because of an observation-filter glitch.
+fn collect_hidden_backend_ids() -> Result<HashSet<u32>, String> {
+    // Use `DOM.getDocument` + `DOM.querySelectorAll(selector)` per hide
+    // selector — returns node IDs directly which we map to backend IDs via
+    // `DOM.describeNode`.  All calls are best-effort; the caller handles
+    // any propagated error by treating the hidden set as empty.
+    with_tab(|tab| -> Result<HashSet<u32>, String> {
+        let mut out = HashSet::new();
+        // Get the document root nodeId.
+        let doc = tab
+            .call_method(DOM::GetDocument { depth: Some(0), pierce: Some(false) })
+            .map_err(|e| format!("DOM.getDocument: {e}"))?;
+        let root_id = doc.root.node_id;
+
+        // For each hide selector, ask Chrome to return matching node IDs
+        // and resolve them to backend IDs in a single batch.
+        let selectors = [
+            "[data-sirin-hide]",
+            "[data-claude-hide]",
+            "#__sirin_indicator_border__",
+            "#__sirin_indicator_badge__",
+        ];
+        for sel in selectors {
+            let res = tab.call_method(DOM::QuerySelectorAll {
+                node_id: root_id,
+                selector: sel.to_string(),
+            });
+            let ids = match res {
+                Ok(r) => r.node_ids,
+                Err(_) => continue,  // selector miss (e.g. no element) — fine
+            };
+            for nid in ids {
+                if let Ok(desc) = tab.call_method(DOM::DescribeNode {
+                    node_id: Some(nid),
+                    backend_node_id: None,
+                    object_id: None,
+                    depth: Some(0),
+                    pierce: Some(false),
+                }) {
+                    let bid = desc.node.backend_node_id as u32;
+                    out.insert(bid);
+                }
+            }
+        }
+        Ok(out)
+    })
 }
 
 fn fetch_tree_raw() -> Result<serde_json::Value, String> {

--- a/src/test_runner/executor.rs
+++ b/src/test_runner/executor.rs
@@ -457,6 +457,24 @@ pub async fn execute_test_tracked(
     }
     let _mask_guard = MaskGuard(prev_mask);
 
+    // 0-ind) Action indicator (Issue #75) — opt-in.  Toggle the global flag
+    // and install a RAII guard that restores the previous value AND removes
+    // the in-page DOM nodes on drop (so the next test starts clean even if
+    // it doesn't opt in).
+    let prev_indicator = crate::browser::set_action_indicator(test.show_action_indicator);
+    /// RAII guard for the action indicator: restores the previous global
+    /// flag and tears down the DOM badge/border on drop.
+    struct IndicatorGuard(bool);
+    impl Drop for IndicatorGuard {
+        fn drop(&mut self) {
+            crate::browser::set_action_indicator(self.0);
+            // Best-effort DOM cleanup — runs even on panic / early return.
+            // Failures are debug-logged inside `hide_action_indicator`.
+            crate::browser::hide_action_indicator();
+        }
+    }
+    let _indicator_guard = IndicatorGuard(prev_indicator);
+
     // 0) Ensure browser launched in the right headless mode.
     // Flutter CanvasKit/WebGL needs headless=false to actually paint.
     let want_headless = test.browser_headless.unwrap_or_else(crate::browser::default_headless);
@@ -591,6 +609,15 @@ pub async fn execute_test_tracked(
         inject_session(&mut ea, session_id);
         let _ = ctx.call_tool("web_navigate", ea).await;
         tracing::debug!("[test_runner] '{}' — post-auto-login enable_a11y OK", test.id);
+    }
+
+    // Issue #75: inject the action indicator now that the page is ready
+    // (no-op if `show_action_indicator` is false).  We do this AFTER
+    // navigate so it lands on the test target page, not the previous one.
+    if test.show_action_indicator {
+        let _ = tokio::task::spawn_blocking(|| {
+            crate::browser::show_action_indicator("starting");
+        }).await;
     }
 
     // 2c) Run fixture setup steps (failure aborts the test before the ReAct loop).
@@ -788,6 +815,15 @@ pub async fn execute_test_tracked(
                     step: (iteration + 1),
                     current_action: action_label.clone(),
                 });
+            }
+            // Issue #75: refresh the in-page action indicator with the
+            // current action.  No-op when `show_action_indicator` is false.
+            // Done in spawn_blocking — `with_tab` inside takes a Mutex.
+            {
+                let label = format!("{} ({}/{})", action_label, iteration + 1, max_iter);
+                let _ = tokio::task::spawn_blocking(move || {
+                    crate::browser::show_action_indicator(&label);
+                }).await;
             }
             // Dispatch to the appropriate tool.  `expand_observation` is a
             // meta-tool (reads run registry, no browser action).  Everything else

--- a/src/test_runner/mod.rs
+++ b/src/test_runner/mod.rs
@@ -249,6 +249,7 @@ pub fn spawn_adhoc_run(req: AdhocRunRequest) -> Result<String, String> {
         mask_sensitive: None,  // None → executor defaults to fail-secure on
         blocked_url_patterns: req.blocked_url_patterns.clone().unwrap_or_default(),
         record_timeline_gif: true,  // adhoc runs default-on; same as YAML default
+        show_action_indicator: false,  // Issue #75: opt-in only; ad-hoc keeps clean DOM
     };
 
     let run_id = runs::new_run(&test_id);
@@ -728,6 +729,7 @@ pub fn persist_adhoc_run(p: PersistAdhocParams) -> Result<PersistAdhocResult, St
         mask_sensitive: goal.mask_sensitive,
         blocked_url_patterns: goal.blocked_url_patterns.clone(),
         record_timeline_gif: goal.record_timeline_gif,
+        show_action_indicator: goal.show_action_indicator,
     };
 
     // Serialize and write.  serde_yaml uses 2-space indent and never
@@ -791,6 +793,7 @@ mod persist_tests {
             mask_sensitive: None,
             blocked_url_patterns: Vec::new(),
             record_timeline_gif: true,
+            show_action_indicator: false,
         };
         let run_id = runs::new_run(test_id);
         runs::set_goal(&run_id, goal.clone());
@@ -878,6 +881,7 @@ mod persist_tests {
             mask_sensitive: None,
             blocked_url_patterns: Vec::new(),
             record_timeline_gif: false,  // synthetic placeholder — never executes
+            show_action_indicator: false,
         });
         runs::set_phase(&run_id, runs::RunPhase::Running {
             step: 2,
@@ -963,6 +967,7 @@ mod persist_tests {
             mask_sensitive: None,
             blocked_url_patterns: Vec::new(),
             record_timeline_gif: true,
+            show_action_indicator: false,
         };
         // Insert directly into SQLite — simulates the row that
         // record_run wrote at the original run completion.

--- a/src/test_runner/parser.rs
+++ b/src/test_runner/parser.rs
@@ -149,6 +149,20 @@ pub struct TestGoal {
     /// is too expensive (slow Flutter pages).
     #[serde(default = "default_record_timeline_gif")]
     pub record_timeline_gif: bool,
+    /// Inject an in-page action indicator (right-bottom badge + faint border)
+    /// during this run so the user can SEE that Sirin is driving the page
+    /// (Issue #75 —对标 CiC's agent-visual-indicator).  The badge text
+    /// updates to the current ReAct action label on every iteration; the
+    /// indicator is hidden automatically before each screenshot / AX-tree
+    /// observation so it never pollutes failure captures or the LLM's view
+    /// of the page.
+    ///
+    /// Default `false` — headless CI and parallel batch runs need a clean
+    /// DOM.  Opt in only for interactive demos / supervised runs where the
+    /// extra DOM nodes are wanted.  Note: the indicator is **UX, not a
+    /// security boundary** — page JS can read its existence trivially.
+    #[serde(default)]
+    pub show_action_indicator: bool,
 }
 
 fn default_record_timeline_gif() -> bool { true }


### PR DESCRIPTION
Closes #75

## 動機
對標 Claude in Chrome：使用者看 Sirin 在跑時知道現在做什麼；HIDE_FOR_TOOL_USE 避免 prompt injection 與其他想隱藏給 agent 看的元素污染觀察。

## 實作
- **DOM overlay inject** — 右下角 badge（monospace 文字）+ 全螢幕 pulsing 邊框，配色用 Sirin 主題（#00FFA3 / #1A1A1A）
- **每個 action 邊界 update** — ReAct loop 每輪以 `<action> (i/N)` 更新 badge 文字
- **截圖前隱藏** — `screenshot` / `screenshot_jpeg` / `screenshot_element` 透過 CSS `visibility:hidden` 隱藏指示器 + `data-sirin-hide`/`data-claude-hide` 元素
- **HIDE_FOR_TOOL_USE 屬性** — 截圖 + AX tree 雙路過濾（AX 路徑透過 backend node ID 集合移除）
- **Opt-in flag** — `show_action_indicator: bool` YAML 欄位，預設 `false`（headless CI 保乾淨 DOM）
- **RAII 雙保險** — `IndicatorGuard` Drop 時恢復 flag + 強制清理 DOM，panic / early return 都不會洩漏到下一個測試
- **與 #80 privacy mask 並存** — 獨立 style id，inject/remove 獨立 pair，零互鎖

## 改動位置 (374 LOC, 含註釋與 3 個 unit test)
- \`src/browser.rs\` — set/show/hide_action_indicator + HIDE_FOR_TOOL_USE inject/remove；wired into 3 screenshot 函式
- \`src/browser_ax.rs\` — \`get_full_tree\` 過濾隱藏 backend ID
- \`src/test_runner/parser.rs\` — \`show_action_indicator\` 欄位
- \`src/test_runner/executor.rs\` — IndicatorGuard + 每輪 update + 啟動時 inject
- \`src/test_runner/mod.rs\` — 4 個 TestGoal 字面建構處補新欄位（adhoc/permanent/3 test 用）

## 驗證
- `cargo check` — 0 error
- 3 個新 unit test 全部 pass：
  - `action_indicator_toggle_round_trips`
  - `action_indicator_inject_js_escapes_action_label`（backticks / backslashes 不能脫出 JS template literal）
  - `hide_for_tool_use_css_hides_indicator_and_data_attrs`
- 既有測試零 regression：browser 30 / parser 14 全綠

## 注意事項
HIDE_FOR_TOOL_USE 是 **UX 而非 security boundary** — agent 仍可透過 `eval` 讀 source DOM 繞過。契約是「不要在 default 觀察通道（AX tree / screenshot）給 LLM 看」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)