### PR TITLE
feat(browser): dom_snapshot + ref_id 穩定互動系統

### DIFF
--- a/src/adk/tool/builtins.rs
+++ b/src/adk/tool/builtins.rs
@@ -48,6 +48,21 @@ fn required_string_field(input: &Value, key: &str) -> Result<String, String> {
     optional_string_field(input, key).ok_or_else(|| format!("Missing '{key}' string"))
 }
 
+/// Issue #74: resolve `target` (CSS selector) OR `ref_id` (CiC-style stable id
+/// from `dom_snapshot`) into a single CSS selector usable by the legacy
+/// click/type/read/exists/hover paths.  `ref_id` wins when both are present.
+fn resolve_target(input: &Value, fallback_target: &str, action: &str) -> Result<String, String> {
+    if let Some(ref_id) = optional_string_field(input, "ref_id") {
+        return crate::browser::resolve_ref(&ref_id);
+    }
+    if !fallback_target.is_empty() {
+        return Ok(fallback_target.to_string());
+    }
+    Err(format!(
+        "'{action}' requires 'target' (CSS selector) or 'ref_id' (from dom_snapshot)"
+    ))
+}
+
 /// Register all discovered external MCP tools into a registry.
 fn register_mcp_tools(registry: ToolRegistry) -> ToolRegistry {
     let tools = crate::mcp_client::get_discovered_tools();
@@ -660,19 +675,22 @@ pub(super) fn build_full_registry() -> ToolRegistry {
                     "close" => { browser::close(); Ok(json!({ "status": "closed" })) }
 
                     // ── DOM interaction ──────────────────────────────
+                    // Issue #74: each accepts EITHER `target` (selector) OR
+                    // `ref_id` (from dom_snapshot).  resolve_target() handles
+                    // both forms — ref_id wins when both are present.
                     "click" => {
-                        if target.is_empty() { return Err("'click' requires 'target' selector".into()); }
-                        browser::click(&target)?;
-                        Ok(json!({ "status": "clicked", "selector": target }))
+                        let sel = resolve_target(&input, &target, "click")?;
+                        browser::click(&sel)?;
+                        Ok(json!({ "status": "clicked", "selector": sel }))
                     }
                     "type" => {
-                        if target.is_empty() { return Err("'type' requires 'target' selector".into()); }
-                        browser::type_text(&target, &text)?;
-                        Ok(json!({ "status": "typed", "selector": target, "length": text.len() }))
+                        let sel = resolve_target(&input, &target, "type")?;
+                        browser::type_text(&sel, &text)?;
+                        Ok(json!({ "status": "typed", "selector": sel, "length": text.len() }))
                     }
                     "read" => {
-                        if target.is_empty() { return Err("'read' requires 'target' selector".into()); }
-                        Ok(json!({ "selector": target, "text": browser::get_text(&target)? }))
+                        let sel = resolve_target(&input, &target, "read")?;
+                        Ok(json!({ "selector": sel, "text": browser::get_text(&sel)? }))
                     }
                     "eval" => {
                         if target.is_empty() { return Err("'eval' requires 'target' JS expression".into()); }
@@ -697,8 +715,26 @@ pub(super) fn build_full_registry() -> ToolRegistry {
                         }
                     }
                     "exists" => {
-                        if target.is_empty() { return Err("'exists' requires 'target' selector".into()); }
-                        Ok(json!({ "selector": target, "exists": browser::element_exists(&target)? }))
+                        // Issue #74: ref_id form returns false (rather than err)
+                        // when the ref is gone — matches the spirit of "does
+                        // this still exist?" instead of bubbling an error up.
+                        if let Some(ref_id) = optional_string_field(&input, "ref_id") {
+                            match browser::resolve_ref(&ref_id) {
+                                Ok(sel) => Ok(json!({
+                                    "ref_id": ref_id,
+                                    "selector": sel,
+                                    "exists": browser::element_exists(&sel)?
+                                })),
+                                Err(_) => Ok(json!({
+                                    "ref_id": ref_id,
+                                    "exists": false
+                                })),
+                            }
+                        } else if !target.is_empty() {
+                            Ok(json!({ "selector": target.clone(), "exists": browser::element_exists(&target)? }))
+                        } else {
+                            Err("'exists' requires 'target' selector or 'ref_id'".into())
+                        }
                     }
                     "count" => {
                         if target.is_empty() { return Err("'count' requires 'target' selector".into()); }
@@ -712,6 +748,21 @@ pub(super) fn build_full_registry() -> ToolRegistry {
                     "value" => {
                         if target.is_empty() { return Err("'value' requires 'target' selector".into()); }
                         Ok(json!({ "selector": target, "value": browser::get_value(&target)? }))
+                    }
+
+                    // ── DOM snapshot (Issue #74) — CiC-style stable refs ─
+                    // `dom_snapshot` walks the visible DOM, assigns each
+                    // interactable element a short ref_id (e1, e2, …), and
+                    // returns {url, count, truncated, elements:[…]}.  Subsequent
+                    // click/type/read/exists/hover accept `ref_id` instead of
+                    // `target` to stay correct across re-renders.
+                    "dom_snapshot" => {
+                        let max = input.get("max")
+                            .and_then(Value::as_u64)
+                            .map(|v| v as usize)
+                            .unwrap_or(browser::DOM_SNAPSHOT_DEFAULT_MAX);
+                        let snap = browser::dom_snapshot(max)?;
+                        Ok(snap)
                     }
 
                     // ── Keyboard / input ─────────────────────────────
@@ -755,9 +806,10 @@ pub(super) fn build_full_registry() -> ToolRegistry {
                         Ok(json!({ "status": "clicked", "x": x, "y": y, "coord_source": source }))
                     }
                     "hover" => {
-                        if target.is_empty() { return Err("'hover' requires 'target' selector".into()); }
-                        browser::hover(&target)?;
-                        Ok(json!({ "status": "hovered", "selector": target }))
+                        // Issue #74: accept ref_id from dom_snapshot.
+                        let sel = resolve_target(&input, &target, "hover")?;
+                        browser::hover(&sel)?;
+                        Ok(json!({ "status": "hovered", "selector": sel }))
                     }
                     "hover_point" => {
                         let x = input.get("x").and_then(|v| v.as_f64()).ok_or("'hover_point' requires 'x'")?;

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1157,6 +1157,182 @@ pub fn get_content() -> Result<String, String> {
     with_tab(|tab| tab.get_content().map_err(|e| format!("get_content: {e}")))
 }
 
+// ── DOM snapshot + ref_id (Issue #74) ────────────────────────────────────────
+//
+// CiC-style stable element references: snapshot the page into a flat list of
+// interactable elements, give each a short ref_id (e1, e2, …), stamp the id
+// onto the element as `data-sirin-ref="eN"` so subsequent actions can locate
+// it via a selector that survives re-renders better than a brittle CSS path.
+//
+// The map is also kept on `window.__sirinRefMap` (WeakRef) so the LLM can
+// re-snapshot mid-test and stale refs auto-evict instead of pointing at the
+// wrong element.  ref_ids RESET on navigation (Chrome wipes window state),
+// which is intentional — the caller should re-snapshot after `goto`.
+
+/// Default cap on snapshot element count.  Pages with >200 interactables
+/// burn LLM context for marginal value; truncate + flag `truncated:true`.
+pub const DOM_SNAPSHOT_DEFAULT_MAX: usize = 200;
+
+/// JS payload that walks the visible DOM, assigns ref_ids, stamps
+/// `data-sirin-ref` and returns a JSON string `{url,elements,truncated}`.
+fn dom_snapshot_js(max: usize) -> String {
+    format!(
+        r#"(function(){{
+  var MAX = {max};
+  window.__sirinRefMap = window.__sirinRefMap || {{}};
+  window.__sirinRefCounter = window.__sirinRefCounter || 0;
+  function getRole(el){{
+    var role = el.getAttribute && el.getAttribute('role');
+    if(role) return role;
+    var tag = el.tagName.toLowerCase();
+    var type = (el.getAttribute && el.getAttribute('type')) || '';
+    var map = {{a:'link', button:'button', select:'combobox',
+                textarea:'textbox', h1:'heading', h2:'heading',
+                h3:'heading', h4:'heading', h5:'heading', h6:'heading'}};
+    if(tag==='input'){{
+      if(type==='checkbox') return 'checkbox';
+      if(type==='radio') return 'radio';
+      if(type==='submit'||type==='button') return 'button';
+      return 'textbox';
+    }}
+    return map[tag] || 'generic';
+  }}
+  function getName(el){{
+    var n = (el.getAttribute && (el.getAttribute('aria-label')
+                              || el.getAttribute('placeholder')
+                              || el.getAttribute('title')
+                              || el.getAttribute('alt'))) || '';
+    if(!n && el.children && el.children.length===0){{
+      n = (el.textContent || '').trim();
+    }}
+    return (n || '').trim().slice(0, 100);
+  }}
+  function isVisible(el){{
+    if(!el || !el.getBoundingClientRect) return false;
+    var s = window.getComputedStyle(el);
+    if(s.display==='none' || s.visibility==='hidden') return false;
+    return el.offsetWidth > 0 && el.offsetHeight > 0;
+  }}
+  function isInteresting(el){{
+    var tag = el.tagName.toLowerCase();
+    if(['script','style','meta','link','noscript','head'].indexOf(tag) >= 0) return false;
+    if(['a','button','input','select','textarea'].indexOf(tag) >= 0) return true;
+    if(el.getAttribute){{
+      if(el.getAttribute('onclick') !== null) return true;
+      if(el.getAttribute('tabindex') !== null) return true;
+      if(el.getAttribute('contenteditable') === 'true'
+        || el.getAttribute('contenteditable') === '') return true;
+      var role = el.getAttribute('role');
+      if(role && ['button','link','tab','checkbox','radio','combobox','menuitem','option']
+                  .indexOf(role) >= 0) return true;
+    }}
+    return false;
+  }}
+  function getOrCreateRef(el){{
+    var existing = el.getAttribute && el.getAttribute('data-sirin-ref');
+    if(existing){{
+      var ref = window.__sirinRefMap[existing];
+      if(ref && ref.deref && ref.deref() === el) return existing;
+    }}
+    var id = 'e' + (++window.__sirinRefCounter);
+    try {{ window.__sirinRefMap[id] = new WeakRef(el); }}
+    catch(e) {{ window.__sirinRefMap[id] = {{deref:function(){{return el;}}}}; }}
+    if(el.setAttribute) el.setAttribute('data-sirin-ref', id);
+    return id;
+  }}
+  // GC sweep: drop refs whose target is gone.
+  for(var k in window.__sirinRefMap){{
+    var w = window.__sirinRefMap[k];
+    if(w && w.deref && !w.deref()) delete window.__sirinRefMap[k];
+  }}
+  var out = [];
+  var truncated = false;
+  var all = document.querySelectorAll('*');
+  for(var i=0;i<all.length;i++){{
+    var el = all[i];
+    if(!isInteresting(el)) continue;
+    if(!isVisible(el)) continue;
+    if(out.length >= MAX){{ truncated = true; break; }}
+    var rect = el.getBoundingClientRect();
+    var ref = getOrCreateRef(el);
+    out.push({{
+      ref: ref,
+      role: getRole(el),
+      name: getName(el),
+      tag: el.tagName.toLowerCase(),
+      bbox: [Math.round(rect.x), Math.round(rect.y),
+             Math.round(rect.width), Math.round(rect.height)],
+      href: (el.getAttribute && el.getAttribute('href')) || null,
+      type: (el.getAttribute && el.getAttribute('type')) || null
+    }});
+  }}
+  return JSON.stringify({{
+    url: window.location.href,
+    count: out.length,
+    truncated: truncated,
+    elements: out
+  }});
+}})()"#
+    )
+}
+
+/// Walk the page DOM and return a JSON snapshot of interactable elements.
+/// Caps at `max` (default `DOM_SNAPSHOT_DEFAULT_MAX`); when exceeded the
+/// returned object includes `truncated: true`.
+pub fn dom_snapshot(max: usize) -> Result<serde_json::Value, String> {
+    let cap = if max == 0 { DOM_SNAPSHOT_DEFAULT_MAX } else { max };
+    let raw = evaluate_js(&dom_snapshot_js(cap))?;
+    serde_json::from_str::<serde_json::Value>(&raw).map_err(|e| {
+        let preview: String = raw.chars().take(200).collect();
+        format!("dom_snapshot: parse JS result: {e} (raw: {preview})")
+    })
+}
+
+/// Resolve a ref_id (from `dom_snapshot`) to a CSS selector usable by
+/// `click` / `type` / `get_text` / `element_exists` / `hover`.
+/// Errors if the ref is unknown or the element has been removed.
+pub fn resolve_ref(ref_id: &str) -> Result<String, String> {
+    if !is_valid_ref_id(ref_id) {
+        return Err(format!("invalid ref_id format: {ref_id:?} (expected eN)"));
+    }
+    let probe = format!(
+        r#"(function(){{
+            var m = window.__sirinRefMap || {{}};
+            var w = m['{ref_id}'];
+            var el = w && w.deref && w.deref();
+            if(!el) return 'GONE';
+            if(!document.body.contains(el)) return 'DETACHED';
+            if(el.getAttribute('data-sirin-ref') !== '{ref_id}'){{
+              el.setAttribute('data-sirin-ref', '{ref_id}');
+            }}
+            return 'OK';
+        }})()"#
+    );
+    let status = evaluate_js(&probe)?;
+    let trimmed = status.trim().trim_matches('"');
+    if trimmed != "OK" {
+        return Err(format!(
+            "ref_id '{ref_id}' {trimmed} — page may have re-rendered or navigated; \
+             call dom_snapshot again"
+        ));
+    }
+    Ok(ref_selector(ref_id))
+}
+
+/// Pure helper: validate a ref_id against the `eN` schema (e1, e42, …).
+pub fn is_valid_ref_id(ref_id: &str) -> bool {
+    let bytes = ref_id.as_bytes();
+    if bytes.len() < 2 { return false; }
+    if bytes[0] != b'e' { return false; }
+    bytes[1..].iter().all(|b| b.is_ascii_digit())
+}
+
+/// Pure helper: build the CSS selector that matches an element stamped by
+/// `dom_snapshot`.
+pub fn ref_selector(ref_id: &str) -> String {
+    format!(r#"[data-sirin-ref="{ref_id}"]"#)
+}
+
 // ── Wait ─────────────────────────────────────────────────────────────────────
 
 /// Wait for a CSS selector to appear in the DOM (default timeout from Tab).
@@ -2649,6 +2825,55 @@ mod tests {
     // ── Pure unit tests (no Chrome needed) ────────────────────────────────────
 
     // ── Issue #79: HiDPI screenshot↔CSS pixel conversion ──────────────────────
+
+    // ── Issue #74: dom_snapshot + ref_id helpers ─────────────────────────────
+
+    #[test]
+    fn ref_id_validates_eN_schema() {
+        assert!(is_valid_ref_id("e1"));
+        assert!(is_valid_ref_id("e42"));
+        assert!(is_valid_ref_id("e9999"));
+        // Invalid forms
+        assert!(!is_valid_ref_id(""));
+        assert!(!is_valid_ref_id("e"));
+        assert!(!is_valid_ref_id("ref_1"));        // CiC-style not accepted
+        assert!(!is_valid_ref_id("E1"));           // case-sensitive
+        assert!(!is_valid_ref_id("e1a"));          // trailing non-digit
+        assert!(!is_valid_ref_id("1e"));
+        assert!(!is_valid_ref_id("e-1"));
+        // Selector-injection attempts must NOT validate.
+        assert!(!is_valid_ref_id(r#"e1"]"#));
+        assert!(!is_valid_ref_id("e1; drop"));
+    }
+
+    #[test]
+    fn ref_selector_quotes_attribute_consistently() {
+        assert_eq!(ref_selector("e1"), r#"[data-sirin-ref="e1"]"#);
+        assert_eq!(ref_selector("e42"), r#"[data-sirin-ref="e42"]"#);
+        // Selector must be a valid CSS attr-equals, idempotent,
+        // and round-trippable through is_valid_ref_id for the inner id.
+        let sel = ref_selector("e7");
+        assert!(sel.starts_with("[data-sirin-ref="));
+        assert!(sel.ends_with("\"]"));
+    }
+
+    #[test]
+    fn dom_snapshot_js_embeds_max_and_returns_callable_iife() {
+        // Pure unit test of the JS payload generator — no Chrome.
+        let js = dom_snapshot_js(50);
+        assert!(js.starts_with("(function(){"));
+        assert!(js.trim_end().ends_with("})()"));
+        assert!(js.contains("var MAX = 50"), "MAX must be embedded literally");
+        assert!(js.contains("__sirinRefMap"));
+        assert!(js.contains("data-sirin-ref"));
+        // No leftover Rust-format placeholders.
+        assert!(!js.contains("{max}"), "format placeholder leaked into JS");
+        assert!(!js.contains("{{") || js.contains("{{a:'link'"), "literal braces only inside object literals");
+
+        // Default cap.
+        let big = dom_snapshot_js(DOM_SNAPSHOT_DEFAULT_MAX);
+        assert!(big.contains(&format!("var MAX = {}", DOM_SNAPSHOT_DEFAULT_MAX)));
+    }
 
     #[test]
     fn viewport_ctx_dpr_2x_screenshot_to_css_halves_coords() {

--- a/src/test_runner/executor.rs
+++ b/src/test_runner/executor.rs
@@ -1343,12 +1343,19 @@ fn build_prompt_with_limits(
 ## Available browser actions (call via tool "web_navigate", field "action")
 - goto           — target: URL
 - screenshot     — capture page PNG
-- click          — target: CSS selector OR plain text label (e.g. "使用用戶名密碼登入"); plain text triggers XPath text search
-- type           — target: CSS selector, text: input text
-- read           — target: CSS selector → returns innerText
+- dom_snapshot   — ⭐ CiC-style stable element refs for standard HTML pages (Issue #74).
+                   Returns {{url, count, truncated, elements:[{{ref:"e3",role,name,tag,bbox}}, …]}}.
+                   Pass `ref_id: "e3"` to click/type/read/exists/hover instead of `target` —
+                   the ref survives re-renders better than a brittle CSS selector.
+                   Optional `max` param caps element count (default 200, sets `truncated:true`).
+                   ⚠️ ref_ids reset after `goto` — re-snapshot after navigation.
+                   ⚠️ Flutter / canvas pages: prefer shadow_*/ax_* (this targets standard HTML).
+- click          — target: CSS selector OR plain text label (XPath text search); OR pass `ref_id` from dom_snapshot
+- type           — target: CSS selector (or `ref_id`), text: input text
+- read           — target: CSS selector (or `ref_id`) → returns innerText
 - eval           — target: JS expression → returns result
 - wait           — target: CSS selector (waits for element) OR plain ms number (sleeps, e.g. "2000")
-- exists         — target: CSS selector → true/false
+- exists         — target: CSS selector (or `ref_id`) → true/false
 - attr           — target: selector, text: attribute name
 - scroll         — x, y: pixels (default 0, 300)
 - scroll_to      — target: selector


### PR DESCRIPTION
Closes #74

## 動機

對標 Claude in Chrome：取代 fragile CSS selector，給 LLM 穩定 ref_id。

CiC 的 `accessibility-tree.js` content script 為每個 DOM 元素分配持久 `ref_id`（如 `ref_3`），讓後續 Claude 直接 `click ref_id=ref_3`，不需要重新描述「那個寫著立即購買的按鈕」。Sirin 過去動態頁面更新後 CSS selector 可能失效或 LLM 重新描述時找錯元素。

## 實作

- **`browser::dom_snapshot(max)`** — 遍歷可見 DOM，為每個 interactable element 分配短 ref_id (`e1`, `e2`, …)，stamp 到元素 `data-sirin-ref` 屬性並存進 `window.__sirinRefMap` (WeakRef GC-safe)；超過 `max`（預設 200）時截斷並設 `truncated:true` 避免炸 LLM context
- **`browser::resolve_ref(ref_id)`** — 確認 ref 仍在 DOM 內，必要時 re-stamp 屬性，回傳 `[data-sirin-ref=\"eN\"]` selector
- **`web_navigate` action `dom_snapshot`** — 暴露給 LLM
- **`click` / `type` / `read` / `exists` / `hover`** 新增 `ref_id` 參數支援（與既有 `target` 並存；`ref_id` 優先；`exists` 對 stale ref 回傳 false 而非錯誤）
- **`test_runner::executor.rs`** prompt 增加 dom_snapshot 描述

## 使用示範（LLM 視角）

\`\`\`
# Step 1
action: dom_snapshot
→ {\"elements\":[{\"ref\":\"e4\",\"role\":\"button\",\"name\":\"加入購物車\",...},
                {\"ref\":\"e5\",\"role\":\"button\",\"name\":\"立即購買\",...},
                {\"ref\":\"e6\",\"role\":\"textbox\",\"name\":\"數量\",...}], ...}

# Step 2 — 不需重新找元素
action: type
ref_id: e6
text: \"2\"

action: click
ref_id: e5
\`\`\`

## 與既有工具的關係（並存，非替代）

| 工具 | 場景 | 穩定性 |
|------|------|--------|
| `ax_*` (`ax_find` / `ax_click`) | Flutter / ARIA-rich HTML | ✅ CDP backend_id |
| `dom_snapshot` + `ref_id` | 標準 HTML（含無 ARIA 元素） | ✅ WeakRef DOM node |
| `shadow_*` | Flutter Canvas | ✅ Flutter 語意樹 |
| 既有 CSS selector | 靜態頁面 | ⚠️ 動態更新可能失效 |

## 驗證

- `cargo check` 0 error
- 3 個 unit test 全 pass：
  - `ref_id_validates_eN_schema` — 驗證 schema + 拒絕 selector-injection 嘗試
  - `ref_selector_quotes_attribute_consistently` — selector 格式
  - `dom_snapshot_js_embeds_max_and_returns_callable_iife` — JS payload 生成正確

## 改動範圍

- `src/browser.rs` +225 行（含 unit tests）
- `src/adk/tool/builtins.rs` +60 行
- `src/test_runner/executor.rs` +14 行（prompt）
- 共 ~301 LOC，在 350 LOC 預算內

🤖 Generated with [Claude Code](https://claude.com/claude-code)