### PR TITLE
feat(web): /mcp gateway HTML page — CiC self-discovery (Closes #90)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ mod log_buffer;
 #[allow(dead_code)] mod integrations;
 #[allow(dead_code)] mod assistant;
 #[allow(dead_code)] mod perception;
+mod mcp_gateway;
 mod mcp_server;
 pub mod monitor;
 mod process_group;

--- a/src/mcp_gateway.html
+++ b/src/mcp_gateway.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Sirin MCP Gateway</title>
+<meta name="sirin-mcp-endpoint" content="/mcp">
+<style>
+:root { --bg:#1A1A1A; --card:#222; --border:#333; --fg:#E0E0E0; --sub:#808080; --ok:#00FFA3; --err:#FF4B4B; --info:#4DA6FF; --num:#FFF; }
+* { box-sizing: border-box; }
+body { background: var(--bg); color: var(--fg); margin: 0; padding: 24px; font-family: ui-monospace, "JetBrains Mono", "Cascadia Code", monospace; font-size: 13px; line-height: 1.5; }
+h1 { color: var(--num); font-size: 18px; margin: 0 0 4px; font-weight: 600; }
+.lede { color: var(--sub); margin: 0 0 20px; } .lede code { color: var(--info); }
+#status { color: var(--sub); margin-bottom: 16px; } #status.ok { color: var(--ok); } #status.err { color: var(--err); }
+details { background: var(--card); border: 1px solid var(--border); border-radius: 4px; padding: 8px 12px; margin-bottom: 8px; }
+details:hover { border-color: #555; }
+summary { cursor: pointer; user-select: none; padding: 4px 0; color: var(--num); font-weight: 600; }
+summary .desc { color: var(--sub); font-weight: 400; margin-left: 8px; }
+summary .ro { color: var(--info); margin-left: 8px; font-size: 11px; }
+summary .wr { color: var(--err); margin-left: 8px; font-size: 11px; }
+.form { padding: 12px 0 4px; display: grid; gap: 8px; }
+label { display: grid; grid-template-columns: 180px 1fr; gap: 8px; align-items: center; }
+label .req { color: var(--err); } label .ptype { color: var(--sub); font-size: 11px; }
+input[type=text], textarea { background: var(--bg); color: var(--fg); border: 1px solid var(--border); border-radius: 3px; padding: 6px 8px; font-family: inherit; font-size: 12px; width: 100%; }
+input[type=text]:focus, textarea:focus { outline: none; border-color: var(--info); }
+textarea { min-height: 56px; resize: vertical; }
+button { background: var(--bg); color: var(--ok); border: 1px solid var(--ok); border-radius: 3px; padding: 6px 14px; cursor: pointer; font-family: inherit; font-size: 12px; justify-self: start; }
+button:hover { background: var(--ok); color: var(--bg); }
+button[disabled] { opacity: 0.5; cursor: wait; }
+pre.result, pre.error { background: var(--bg); border: 1px solid var(--border); border-radius: 3px; padding: 8px; margin: 8px 0 0; max-height: 400px; overflow: auto; white-space: pre-wrap; word-break: break-word; font-size: 12px; }
+pre.error { border-color: var(--err); color: var(--err); }
+pre.result { color: var(--num); }
+.write-only { padding: 8px 0 0; color: var(--sub); font-style: italic; font-size: 12px; }
+</style>
+</head>
+<body>
+<h1>Sirin MCP Gateway</h1>
+<p class="lede">Same-origin <code>POST /mcp</code> endpoint &mdash; JSON-RPC 2.0. No CORS.</p>
+<div id="status">Loading tools...</div>
+<div id="tools"></div>
+<script>
+// Tools whose name contains any of these keywords are listed but no form is
+// rendered &mdash; safe-by-default for the CiC self-discovery use case.
+const WRITE_KEYWORDS = ["write","delete","create","spawn","send","approve","reset","kill"];
+function esc(s) {
+  return String(s == null ? "" : s).replace(/&/g,"&amp;").replace(/</g,"&lt;")
+    .replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#39;");
+}
+function isWriteTool(name) {
+  const lower = String(name || "").toLowerCase();
+  return WRITE_KEYWORDS.some(k => lower.includes(k));
+}
+async function rpc(method, params) {
+  const r = await fetch("/mcp", { method: "POST",
+    headers: {"content-type": "application/json"},
+    body: JSON.stringify({jsonrpc: "2.0", id: Date.now(), method, params: params || {}}) });
+  if (!r.ok) throw new Error("HTTP " + r.status + " " + r.statusText);
+  const j = await r.json();
+  if (j.error) throw new Error(JSON.stringify(j.error));
+  return j.result;
+}
+function renderField(propName, propSchema, required) {
+  const type = (propSchema && propSchema.type) || "string";
+  const desc = (propSchema && propSchema.description) || "";
+  const reqMark = required ? '<span class="req">*</span>' : "";
+  const ptype = '<span class="ptype">' + esc(type) + (desc ? " &mdash; " + esc(desc) : "") + '</span>';
+  const attrs = 'data-name="' + esc(propName) + '" data-type="' + esc(type) + '"' + (required ? ' required' : '');
+  const input = (type === "object" || type === "array")
+    ? '<textarea ' + attrs + ' placeholder="JSON"></textarea>'
+    : '<input type="text" ' + attrs + '>';
+  return '<label><span>' + esc(propName) + reqMark + '<br>' + ptype + '</span>' + input + '</label>';
+}
+function collectArgs(formEl) {
+  const args = {};
+  formEl.querySelectorAll("[data-name]").forEach(el => {
+    const name = el.getAttribute("data-name");
+    const type = el.getAttribute("data-type") || "string";
+    const raw = el.value;
+    if (raw === "" || raw == null) return;
+    if (type === "number" || type === "integer") {
+      const n = Number(raw); if (!Number.isNaN(n)) args[name] = n;
+    } else if (type === "boolean") { args[name] = (raw === "true" || raw === "1");
+    } else if (type === "object" || type === "array") {
+      try { args[name] = JSON.parse(raw); }
+      catch (e) { throw new Error("field '" + name + "': invalid JSON: " + e.message); }
+    } else { args[name] = raw; }
+  });
+  return args;
+}
+async function runTool(toolName, formEl, resultEl, errorEl, btn) {
+  resultEl.style.display = "none"; errorEl.style.display = "none";
+  btn.disabled = true; btn.textContent = "Running...";
+  try {
+    const args = collectArgs(formEl);
+    const result = await rpc("tools/call", {name: toolName, arguments: args});
+    resultEl.textContent = JSON.stringify(result, null, 2);
+    resultEl.style.display = "block";
+  } catch (e) {
+    errorEl.textContent = String(e && e.message ? e.message : e);
+    errorEl.style.display = "block";
+  } finally { btn.disabled = false; btn.textContent = "Run"; }
+}
+function renderTool(tool) {
+  const wrap = document.createElement("details");
+  const writeOnly = isWriteTool(tool.name);
+  const tagHtml = writeOnly
+    ? '<span class="wr">[has side effects &mdash; form hidden]</span>'
+    : '<span class="ro">[read-only]</span>';
+  const desc = tool.description ? '<span class="desc">&mdash; ' + esc(tool.description) + '</span>' : "";
+  const summary = document.createElement("summary");
+  summary.innerHTML = esc(tool.name) + tagHtml + desc;
+  wrap.appendChild(summary);
+  if (writeOnly) {
+    const note = document.createElement("div");
+    note.className = "write-only";
+    note.textContent = "This tool's name matches a write/side-effect keyword. Form intentionally hidden. Call directly via POST /mcp tools/call if intended.";
+    wrap.appendChild(note); return wrap;
+  }
+  const schema = tool.inputSchema || {};
+  const props = schema.properties || {};
+  const required = new Set(schema.required || []);
+  const form = document.createElement("div");
+  form.className = "form";
+  let fieldsHtml = "";
+  Object.keys(props).forEach(p => { fieldsHtml += renderField(p, props[p], required.has(p)); });
+  form.innerHTML = fieldsHtml;
+  const btn = document.createElement("button");
+  btn.type = "button"; btn.textContent = "Run";
+  form.appendChild(btn);
+  const result = document.createElement("pre"); result.className = "result"; result.style.display = "none";
+  const error = document.createElement("pre"); error.className = "error"; error.style.display = "none";
+  form.appendChild(result); form.appendChild(error);
+  btn.addEventListener("click", () => runTool(tool.name, form, result, error, btn));
+  wrap.appendChild(form); return wrap;
+}
+async function init() {
+  const status = document.getElementById("status");
+  const root = document.getElementById("tools");
+  try {
+    const result = await rpc("tools/list", {});
+    const tools = (result && result.tools) || [];
+    tools.sort((a, b) => String(a.name).localeCompare(String(b.name)));
+    status.textContent = tools.length + " tool(s) loaded.";
+    status.className = "ok";
+    tools.forEach(t => root.appendChild(renderTool(t)));
+  } catch (e) {
+    status.textContent = "Failed to load tools: " + (e && e.message ? e.message : e);
+    status.className = "err";
+  }
+}
+if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init);
+else init();
+</script>
+</body>
+</html>

--- a/src/mcp_gateway.rs
+++ b/src/mcp_gateway.rs
@@ -1,0 +1,80 @@
+//! `GET /` &mdash; HTML gateway page for the MCP endpoint.
+//!
+//! Purpose: give Claude in Chrome (Beta) a same-origin page it can `navigate`
+//! to and then drive with `javascript_tool` (or plain `read_page` + form
+//! `click`) to call any MCP tool without hitting CORS.
+//!
+//! The HTML is fully self-contained &mdash; no external CDN, no build step.
+//! On load it `fetch('/mcp', tools/list)` and renders one `<details>` card
+//! per tool with a form generated from `inputSchema.properties`.  Tools
+//! whose name contains a write/side-effect keyword (write/delete/create/
+//! spawn/send/approve/reset/kill) are listed but their form is suppressed.
+//!
+//! See: <https://github.com/Redandan/Sirin/issues/90>
+
+use axum::response::Html;
+
+/// Embedded gateway page.  Served verbatim &mdash; all dynamic behaviour lives
+/// in the inline JS which calls `POST /mcp tools/list` at load time.
+const GATEWAY_HTML: &str = include_str!("mcp_gateway.html");
+
+/// Axum handler for `GET /`.  Returns the embedded HTML with
+/// `Content-Type: text/html; charset=utf-8` (set by `Html<_>`'s
+/// `IntoResponse` impl).
+pub async fn gateway_handler() -> Html<&'static str> {
+    Html(GATEWAY_HTML)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{response::IntoResponse, http::StatusCode};
+
+    #[tokio::test]
+    async fn gateway_returns_html_with_marker_and_endpoint_meta() {
+        let resp = gateway_handler().await.into_response();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let ct = resp
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.starts_with("text/html"),
+            "expected text/html content-type, got {ct:?}"
+        );
+
+        let body_bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+            .await
+            .expect("read body");
+        let body = std::str::from_utf8(&body_bytes).expect("utf8 body");
+
+        // Tier-1 marker: page identifies itself.
+        assert!(
+            body.contains("Sirin MCP Gateway"),
+            "body missing title marker"
+        );
+        // Future-proof discovery hint &mdash; CiC / scrapers can locate the
+        // JSON-RPC endpoint without hard-coding `/mcp`.
+        assert!(
+            body.contains(r#"name="sirin-mcp-endpoint""#)
+                && body.contains(r#"content="/mcp""#),
+            "body missing sirin-mcp-endpoint meta tag"
+        );
+        // Tier-2 marker: the dynamic-tools script is wired up.
+        assert!(
+            body.contains("tools/list"),
+            "body missing tools/list bootstrapping JS"
+        );
+    }
+
+    #[test]
+    fn gateway_html_is_nonempty() {
+        // include_str! resolution sanity check &mdash; if the asset path ever
+        // moves, the build fails; this also guards against an empty file
+        // sneaking in via a bad merge.
+        assert!(GATEWAY_HTML.len() > 500, "embedded HTML suspiciously short");
+        assert!(GATEWAY_HTML.contains("<!DOCTYPE html>"));
+    }
+}

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -44,7 +44,7 @@ use axum::{
     extract::Json,
     http::{HeaderMap, Method, StatusCode},
     response::IntoResponse,
-    routing::post,
+    routing::{get, post},
     Router,
 };
 use serde_json::{json, Value};
@@ -144,7 +144,11 @@ pub fn mcp_router() -> Router {
     // Browsers send a CORS preflight (OPTIONS) before any cross-origin POST
     // from a `chrome-extension://[id]` page; without this layer the preflight
     // 404s and the extension never gets to send the real request.
+    // `GET /` serves an HTML gateway page so Claude in Chrome (Beta) &mdash;
+    // whose only network primitive is `navigate` + `javascript_tool` &mdash;
+    // can drive the MCP endpoint same-origin (no CORS).  See Issue #90.
     Router::new()
+        .route("/", get(crate::mcp_gateway::gateway_handler))
         .route("/mcp", post(mcp_handler))
         .layer(cors_layer())
         .layer(TimeoutLayer::with_status_code(


### PR DESCRIPTION
## Summary

- Adds `GET /` serving an embedded HTML page (`src/mcp_gateway.html`) so Claude in Chrome (Beta) — whose only network primitive is `navigate` + `javascript_tool` — can drive the MCP endpoint same-origin without hitting CORS.
- Tier 1 (static page reachable, `<meta name="sirin-mcp-endpoint">` for discovery) and Tier 2 (self-discovery forms generated from each tool's `inputSchema`, JSON arg coercion, error rendering) both implemented.
- Tools whose name contains a write/side-effect keyword (`write`/`delete`/`create`/`spawn`/`send`/`approve`/`reset`/`kill`) are listed but their input form is suppressed — read-only safe-by-default. All injected strings are HTML-escaped against tool descriptions containing markup.

## Files

- `src/mcp_gateway.html` (new, 154 LOC) — self-contained: no CDN, no build step, vanilla JS + inline CSS following the project's hardcore-monitor palette.
- `src/mcp_gateway.rs` (new, 80 LOC) — thin axum handler returning `Html<&'static str>` via `include_str!`, plus 2 unit tests.
- `src/mcp_server.rs::mcp_router` — adds `.route("/", get(crate::mcp_gateway::gateway_handler))` ahead of the existing `POST /mcp`. `CorsLayer` + `TimeoutLayer` untouched.
- `src/main.rs` — declares `mod mcp_gateway`.

Total new: 240 LOC (within the ≤250 budget specified in the issue).

## Why this matters

PR #72's `kb_search` / `kb_get` MCP tools are unreachable from CiC today because the CiC tool surface has no MCP client and no `fetch` primitive — only browser automation. This gateway turns any browser tab into an MCP client over `javascript_tool` (or even pure form-click via `read_page` + `click`).

## Test plan

- [x] `cargo check --bin sirin` — 0 errors
- [x] `cargo test --bin sirin -- gateway` — 2/2 pass (`gateway_returns_html_with_marker_and_endpoint_meta`, `gateway_html_is_nonempty`)
- [x] `cargo test --bin sirin -- mcp_router` — existing constructibility test still passes
- [ ] Manual: launch Sirin, `curl http://127.0.0.1:7700/` returns HTML with `Sirin MCP Gateway` title
- [ ] Manual: open `http://127.0.0.1:7700/` in browser, see auto-populated tool cards, expand one read-only tool, fill args, click Run → result `<pre>` populates with JSON-RPC response
- [ ] Manual: from CiC `navigate http://127.0.0.1:7700/` then `javascript_tool` `fetch('/mcp', POST kb_get)` works (validates same-origin no-CORS path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)