### PR TITLE
fix(mcp_gateway): mount at /gateway not / to avoid WS upgrade route conflict

### DIFF
--- a/src/mcp_gateway.rs
+++ b/src/mcp_gateway.rs
@@ -1,4 +1,4 @@
-//! `GET /` &mdash; HTML gateway page for the MCP endpoint.
+//! `GET /gateway` &mdash; HTML gateway page for the MCP endpoint.
 //!
 //! Purpose: give Claude in Chrome (Beta) a same-origin page it can `navigate`
 //! to and then drive with `javascript_tool` (or plain `read_page` + form
@@ -18,7 +18,7 @@ use axum::response::Html;
 /// in the inline JS which calls `POST /mcp tools/list` at load time.
 const GATEWAY_HTML: &str = include_str!("mcp_gateway.html");
 
-/// Axum handler for `GET /`.  Returns the embedded HTML with
+/// Axum handler for `GET /gateway`.  Returns the embedded HTML with
 /// `Content-Type: text/html; charset=utf-8` (set by `Html<_>`'s
 /// `IntoResponse` impl).
 pub async fn gateway_handler() -> Html<&'static str> {

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -144,11 +144,14 @@ pub fn mcp_router() -> Router {
     // Browsers send a CORS preflight (OPTIONS) before any cross-origin POST
     // from a `chrome-extension://[id]` page; without this layer the preflight
     // 404s and the extension never gets to send the real request.
-    // `GET /` serves an HTML gateway page so Claude in Chrome (Beta) &mdash;
+    // `GET /gateway` serves an HTML gateway page so Claude in Chrome (Beta) &mdash;
     // whose only network primitive is `navigate` + `javascript_tool` &mdash;
     // can drive the MCP endpoint same-origin (no CORS).  See Issue #90.
+    // Path is `/gateway` (not `/`) because `rpc_server::start_rpc_server`
+    // already mounts `GET /` as the ext_server WebSocket upgrade route, and
+    // axum `merge` panics on overlapping method handlers.
     Router::new()
-        .route("/", get(crate::mcp_gateway::gateway_handler))
+        .route("/gateway", get(crate::mcp_gateway::gateway_handler))
         .route("/mcp", post(mcp_handler))
         .layer(cors_layer())
         .layer(TimeoutLayer::with_status_code(


### PR DESCRIPTION
## 問題

PR #91 (Issue #90) 把 gateway 掛在 `GET /`，但 `rpc_server::start_rpc_server` 已經掛了 `GET /` 給 ext_server 的 WebSocket upgrade handler ([src/rpc_server.rs:72](https://github.com/Redandan/Sirin/blob/main/src/rpc_server.rs#L72))。axum `Router::merge` 對 overlapping method handler **直接 panic**，RPC server 在 startup 就死掉：

```
thread 'tokio-rt-worker' panicked at src\rpc_server.rs:73:14:
Overlapping method route. Handler for `GET /` already exists
```

## 修法

Gateway 移到 `GET /gateway`。CiC 改 navigate 到：

```
http://127.0.0.1:7700/gateway
```

## 驗證

- `cargo build --release` 0 error
- 手動：`curl http://127.0.0.1:7700/gateway` → 200 text/html 8326B HTML
- 手動：`curl -X POST http://127.0.0.1:7700/mcp ...` 仍正常回 tools/list
- 既有 test 沒測 route path（只測 handler output），自動通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)