### PR TITLE
fix(test+browser): tighten pickup_time_picker spec + with_tab retry 1→3

### DIFF
--- a/config/tests/agora_regression/agora_pickup_time_picker.yaml
+++ b/config/tests/agora_regression/agora_pickup_time_picker.yaml
@@ -1,33 +1,57 @@
 id: agora_pickup_time_picker
 name: "取貨時間選擇器測試"
-url: "https://redandan.github.io/?__test_role=buyer"
+url: "https://redandan.github.io/?__test_role=seller"
 
-max_iterations: 15
-timeout_secs: 240
+max_iterations: 25
+timeout_secs: 360
 
 goal: |
-  目標：探索買家結帳流程，記錄是否有取貨時間選擇器（Issue #70）。
+  目標：實際操作 Flutter 取貨時間選擇器（pickup time picker），把結束時間改成 14:00。
 
-  起始狀態：以買家身份登入，已在首頁（URL auto-login via __test_role=buyer）。
+  ⚠️ 重要：「找不到 picker」**不算 pass**。必須真的找到 + 改值。
+  CiC 在同 task 上花 25 actions 達成此操作（switch role + scroll + toggle 平台配送），
+  Sirin 也應該至少達到同樣深度，不要 LLM 在「沒看到 picker」就放棄。
+
+  起始狀態：以賣家身份登入（URL auto-login via __test_role=seller）。
+  若一開始顯示買家視角，需要 switch role：
+    - shadow_click 「我的」tab → 「切換身份」→ 「賣家」
 
   ⚠️ Flutter app：所有 UI 判斷用 screenshot_analyze 或 shadow_dump。
-  ⚠️ 即使某個步驟找不到元素也繼續往下，不要重試同一步驟。
+  ⚠️ 如果某 step 找不到目標，**先 retry 1 次**；仍找不到才繼續往下。
+  ⚠️ Picker 可能藏在「啟用平台配送」toggle 後面 — 必須先 enable toggle 才會出現取貨資訊區。
 
-  步驟（線性，步驟 10 無條件 done=true）：
-  1. screenshot_analyze "確認在首頁，看到商品卡片"
-  2. shadow_click role=button name_regex="USDT"（點第一個商品卡）
+  步驟：
+  1. screenshot_analyze "確認在賣家頁面，看到上方 tab 列（商品/訂單/我的）"
+  2. shadow_click role=tab name_regex="^商品$"（賣家商品列表）
   3. wait 2000
-  4. screenshot_analyze "是否在商品詳情頁？看到哪些購買相關按鈕？"
-  5. 向下捲動 400px（scroll y=400）
-  6. shadow_dump（列出詳情頁所有 role=button，找購買/結帳按鈕）
-  7. shadow_click role=button name_regex="購買|Buy|加入購物車|Cart|立即|Order|結帳|Checkout"
-  8. wait 3000
-  9. screenshot_analyze "目前在哪個頁面？看到取貨時間選擇器、訂單資訊或購買相關欄位嗎？"
-  10. done=true
+  4. shadow_click role=button name_regex="\\+|新增|上架"（加號 = 開新增商品 form）
+  5. wait 3000
+  6. screenshot_analyze "在新增商品 form 嗎？看到哪些欄位？是否有「平台配送設定」section？"
+  7. 向下捲動找「平台配送設定」section（scroll y=600，最多 retry 2 次）
+  8. shadow_dump（找「啟用平台配送」toggle / switch widget）
+  9. shadow_click role=switch name_regex="啟用平台配送|平台配送"
+  10. wait 1500
+  11. screenshot_analyze "「取貨資訊」區是否出現？看到「取貨開始時間」「取貨結束時間」欄位嗎？"
+  12. ax_find role=textbox name_regex="取貨結束時間|結束時間|18:00"
+  13. ax_click（focus 取貨結束時間欄位，使用 step 12 的 backend_id）
+  14. wait 800
+  15. flutter_type text="14:00"
+  16. wait 800
+  17. flutter_enter（confirm input）
+  18. wait 1500
+  19. screenshot_analyze "取貨結束時間目前顯示什麼？是 14:00 嗎？"
+  20. done=true（**只在 step 19 確認 14:00 後**）
 
 success_criteria:
-  - "從首頁成功點擊商品卡進入詳情頁"
-  - "嘗試點擊購買按鈕並記錄結果（進入結帳頁、或記錄找不到購買按鈕）"
-  - "記錄結帳頁是否出現取貨時段選擇器（有或無都是有效資訊）"
+  - "成功進入賣家「新增商品」form"
+  - "成功展開「平台配送設定」section（包括 enable 啟用平台配送 toggle）"
+  - "**實際操作取貨結束時間欄位，改為 14:00**（必要條件，不接受『找不到 picker』）"
+  - "step 19 截圖驗證 14:00 已生效"
 
-tags: [agora, regression, pickup, checkout]
+failure_modes:
+  # 明示哪些情況算 fail，避免 LLM 自我認定 pass
+  - "如果 LLM report『找不到 picker / 沒看到取貨資訊』就 done=true → 視為 FAIL（spec 要求必須找到並操作）"
+  - "如果連『新增商品 form』都進不去 → FAIL"
+  - "如果『啟用平台配送』toggle 找不到 → FAIL（必須驗證它存在）"
+
+tags: [agora, regression, pickup, checkout, picker]

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -2754,35 +2754,68 @@ where
         }
     }; // mutex released here — NOT held during the CDP call
 
-    let result = f.clone()(&tab);
+    let mut result = f.clone()(&tab);
 
-    // If the call failed with a connection-closed error, try one auto-recover.
-    if let Err(ref e) = result {
-        if is_connection_closed(e) {
-            tracing::warn!("[browser] mid-call connection closed — attempting one-shot recovery");
-            // Clear singleton
-            *global().lock().unwrap_or_else(|e| e.into_inner()) = None;
-            // Re-launch in the mode the current test requested (not default_headless()).
-            // Flutter CanvasKit needs headless=false — using default would silently
-            // re-launch headless and cause a black screen for the rest of the test.
-            let recovery_headless = TEST_DESIRED_HEADLESS.load(Ordering::Relaxed);
-            ensure_open(recovery_headless)?;
-            // Retry exactly once with a fresh tab from the new session.
-            // After recovery the browser has only one tab (index 0) — clamp
-            // the thread-local to what actually exists so we don't panic.
-            let tab: Arc<Tab> = {
-                let guard = global().lock().unwrap_or_else(|e| e.into_inner());
-                match guard.as_ref() {
-                    Some(inner) => {
-                        let idx = THREAD_ACTIVE_TAB.with(|c| c.get())
-                            .unwrap_or(inner.active)
-                            .min(inner.tabs.len().saturating_sub(1));
-                        Arc::clone(&inner.tabs[idx])
+    // If the call failed with a connection-closed error, retry up to
+    // `MAX_RECOVERIES` times.  Pilot #003-rerun (Issue #97) showed
+    // `agora_pickup_time_picker` hitting `net::ERR_ABORTED` repeatedly on
+    // Flutter hash-route transitions — one-shot recovery isn't always enough
+    // when the underlying CDP transport is genuinely flapping.  Each retry
+    // resets the singleton + sleeps briefly to let Chrome settle.
+    const MAX_RECOVERIES: u32 = 3;
+    for attempt in 1..=MAX_RECOVERIES {
+        match &result {
+            Err(e) if is_connection_closed(e) => {
+                tracing::warn!(
+                    "[browser] mid-call connection closed (attempt {}/{}) — recovering",
+                    attempt, MAX_RECOVERIES
+                );
+                // Clear singleton so the next ensure_open spawns a fresh Chrome.
+                *global().lock().unwrap_or_else(|e| e.into_inner()) = None;
+                // Brief settle delay between recoveries — empirically the second+
+                // recovery succeeds when Chrome had a moment to release its locks.
+                std::thread::sleep(std::time::Duration::from_millis(500));
+                // Re-launch in the mode the current test requested (not
+                // default_headless()).  Flutter CanvasKit needs headless=false
+                // — using default would silently re-launch headless and cause
+                // a black screen for the rest of the test.
+                let recovery_headless = TEST_DESIRED_HEADLESS.load(Ordering::Relaxed);
+                if let Err(launch_err) = ensure_open(recovery_headless) {
+                    tracing::error!(
+                        "[browser] recovery attempt {} failed at ensure_open: {}",
+                        attempt, launch_err
+                    );
+                    if attempt == MAX_RECOVERIES {
+                        return Err(format!(
+                            "browser recovery exhausted after {} attempts: {}",
+                            MAX_RECOVERIES, launch_err
+                        ));
                     }
-                    None => return Err("browser session lost after recovery".into()),
+                    continue;
                 }
-            };
-            return f(&tab);
+                // Get a fresh tab from the new session.  After recovery the
+                // browser has only one tab (index 0) — clamp THREAD_ACTIVE_TAB
+                // so we don't panic on out-of-bounds.
+                let tab: Arc<Tab> = {
+                    let guard = global().lock().unwrap_or_else(|e| e.into_inner());
+                    match guard.as_ref() {
+                        Some(inner) => {
+                            let idx = THREAD_ACTIVE_TAB.with(|c| c.get())
+                                .unwrap_or(inner.active)
+                                .min(inner.tabs.len().saturating_sub(1));
+                            Arc::clone(&inner.tabs[idx])
+                        }
+                        None => {
+                            if attempt == MAX_RECOVERIES {
+                                return Err("browser session lost after recovery".into());
+                            }
+                            continue;
+                        }
+                    }
+                };
+                result = f.clone()(&tab);
+            }
+            _ => break, // Ok, or non-connection-closed Err — stop retrying.
         }
     }
 


### PR DESCRIPTION
## 兩個 fix 一個 PR

來自 Pilot #003-rerun 暴露的問題（[cic-bench-pilot-003-report v2](https://github.com/Redandan/Sirin/issues/97)）。

### Fix 1: agora_pickup_time_picker YAML 收緊

| 維度 | Before | After |
|---|---|---|
| Success criteria | 「找到 OR 報告找不到」都 pass | **必須真改 picker 時間**到 14:00 |
| max_iterations | 15 | 25 |
| timeout_secs | 240 | 360 |
| URL | `?__test_role=buyer` | `?__test_role=seller` |
| failure_modes 區段 | 無 | 明列「LLM 自我認定 pass」這類失敗模式 |

對標 CiC 在同 task 上的實作路徑（switch role → form → toggle 啟用平台配送 → 取貨資訊區 → 改時間）寫成 step-by-step instructions。

### Fix 2: src/browser.rs::with_tab retry budget 1 → 3

n=3 sample 看到 `agora_pickup_time_picker` 第 3 次跑時 \"瀏覽器多次重啟\" — Flutter hash-route 切換時 CDP transport 偶發 silent，one-shot recovery 不夠。

```diff
- // Try one auto-recover.
- if let Err(...) = result { ... ensure_open(...); return f(&tab); }
+ const MAX_RECOVERIES: u32 = 3;
+ for attempt in 1..=MAX_RECOVERIES {
+     match &result {
+         Err(e) if is_connection_closed(e) => {
+             // clear singleton + 500ms settle + ensure_open + retry
+         }
+         _ => break,
+     }
+ }
```

新增 500ms settle delay、attempt counter log、ensure_open 失敗也算一次 attempt（不是 short-circuit）。

## 驗證

- `cargo check`: 0 error
- `cargo build --release`: 0 error in 3m 10s
- 之後 Pilot #004 (n=5 benchmark) 預期：`agora_pickup_time_picker` 從 2/3 假性 pass → 真實 pass 或 honest fail（不再含糊）

## 不做

- ❌ 不換 LLM（用戶決定保留 Gemini Flash）
- ❌ 不擴大其他 YAML — 只動 1 個 known flake test
- ❌ 不改 mutex 邏輯（PR #100 那邊 OK）

🤖 Generated with [Claude Code](https://claude.com/claude-code)