### PR TITLE
feat(test_runner): dispute_yaml action — LLM 主動回報 YAML spec issue + 開 GitHub issue (Closes #103)

### DIFF
--- a/src/skills.rs
+++ b/src/skills.rs
@@ -531,10 +531,11 @@ async fn execute_browser_test(user_input: &str) -> Result<String, String> {
 
     let elapsed_s = started.elapsed().as_secs_f64();
     let status_label = match result.status {
-        crate::test_runner::TestStatus::Passed  => "✓ PASSED",
-        crate::test_runner::TestStatus::Failed  => "✗ FAILED",
-        crate::test_runner::TestStatus::Timeout => "⏱ TIMEOUT",
-        crate::test_runner::TestStatus::Error   => "✗ ERROR",
+        crate::test_runner::TestStatus::Passed   => "✓ PASSED",
+        crate::test_runner::TestStatus::Failed   => "✗ FAILED",
+        crate::test_runner::TestStatus::Timeout  => "⏱ TIMEOUT",
+        crate::test_runner::TestStatus::Error    => "✗ ERROR",
+        crate::test_runner::TestStatus::Disputed => "⚠ DISPUTED",
     };
 
     let mut summary = format!(

--- a/src/test_runner/executor.rs
+++ b/src/test_runner/executor.rs
@@ -252,6 +252,152 @@ fn record_guard_fire_to_kb(
     });
 }
 
+/// Handle the `dispute_yaml` action emitted by the LLM.
+///
+/// Three side-effects (all fire-and-forget):
+/// 1. KB write — `yaml-dispute-{test_id}-{run_id}` draft note (if KB_ENABLED=1).
+/// 2. `gh issue create` — opens a GitHub issue on Redandan/Sirin with structured body.
+///    Uses `std::process::Command` so no new crate dependency is needed.
+///
+/// Returns the `DisputeInfo` for the caller to embed in the `TestResult`.
+fn handle_dispute_yaml(
+    test_id: &str,
+    run_id: Option<&str>,
+    iteration: u32,
+    dispute: DisputeInfo,
+    final_url: &str,
+    llm_model: &str,
+) -> DisputeInfo {
+    let ts = chrono::Local::now().to_rfc3339();
+    let rid = run_id.unwrap_or("unknown");
+
+    // ── Layer 2: auto kbWrite ────────────────────────────────────────────────
+    {
+        let topic_key = format!(
+            "yaml-dispute-{}-{}",
+            slugify_for_topic(test_id, 40),
+            slugify_for_topic(rid, 20),
+        );
+        let title = format!("yaml-dispute({test_id}): iter {iteration} — {}", truncate(&dispute.reason, 60));
+        let step_note = dispute
+            .suspected_step
+            .map(|n| format!("Suspected step: {n}"))
+            .unwrap_or_else(|| "Suspected step: (unspecified)".into());
+        let fix_note = dispute
+            .suggested_fix
+            .as_deref()
+            .map(|f| format!("Suggested fix: {f}"))
+            .unwrap_or_else(|| "Suggested fix: (none)".into());
+        let content = format!(
+            "## Dispute report\n\
+             **Test**: `{test_id}`  \n\
+             **Run ID**: `{rid}`  \n\
+             **LLM**: {llm_model}  \n\
+             **Date**: {ts}  \n\
+             **Iteration when dispute fired**: {iteration}\n\n\
+             ## Reason (LLM-provided)\n\
+             > {reason}\n\n\
+             ## {step_note}\n\n\
+             ## {fix_note}\n\n\
+             ## Context\n\
+             - Final URL: {final_url}\n\
+             - KB entry: `{topic_key}`\n",
+            reason = dispute.reason,
+        );
+        let tags = format!("yaml-dispute,test-id-{}", slugify_for_topic(test_id, 30));
+        let tid = test_id.to_string();
+        tokio::spawn(async move {
+            let _ = crate::kb_client::write_raw_to_project(
+                &crate::kb_client::default_project(),
+                &topic_key,
+                &title,
+                &content,
+                "test-yaml-dispute",
+                &tags,
+                &format!("config/tests/{tid}.yaml"),
+            ).await;
+        });
+    }
+
+    // ── Layer 3: auto gh issue create ────────────────────────────────────────
+    {
+        let step_n = dispute.suspected_step.unwrap_or(-1);
+        let reason_short: String = dispute.reason.chars().take(50).collect();
+        let gh_title = if step_n >= 0 {
+            format!("yaml-dispute({test_id}): step {step_n} — {reason_short}")
+        } else {
+            format!("yaml-dispute({test_id}): {reason_short}")
+        };
+        let fix_section = dispute
+            .suggested_fix
+            .as_deref()
+            .map(|f| format!("> {f}"))
+            .unwrap_or_else(|| "(none provided)".into());
+        let step_section = if step_n >= 0 {
+            format!("step {step_n}: *(see YAML)*")
+        } else {
+            "(unspecified)".into()
+        };
+        let slug_test = slugify_for_topic(test_id, 40);
+        let slug_rid  = slugify_for_topic(rid, 20);
+        let gh_body = format!(
+            "## LLM Dispute Report\n\n\
+             **Test**: {test_id}\n\
+             **Run ID**: {rid}\n\
+             **LLM**: {llm_model}\n\
+             **Date**: {ts}\n\n\
+             ### Reason (LLM-provided)\n\
+             > {reason}\n\n\
+             ### Suspected step\n\
+             {step_section}\n\n\
+             ### Suggested fix (LLM-provided, 僅供參考)\n\
+             {fix_section}\n\n\
+             ### Context\n\
+             - URL: {final_url}\n\
+             - Iterations before dispute: {iteration}\n\n\
+             ### Raw context\n\
+             - KB entry: `yaml-dispute-{slug_test}-{slug_rid}`\n",
+            reason = dispute.reason,
+        );
+        let labels = "yaml-dispute,bot-flagged,triage";
+        match std::process::Command::new("gh")
+            .args([
+                "issue", "create",
+                "--repo", "Redandan/Sirin",
+                "--title", &gh_title,
+                "--body", &gh_body,
+                "--label", labels,
+            ])
+            .output()
+        {
+            Ok(out) if out.status.success() => {
+                let url = String::from_utf8_lossy(&out.stdout);
+                tracing::info!(
+                    "[dispute_yaml] '{}' — GitHub issue created: {}",
+                    test_id,
+                    url.trim()
+                );
+            }
+            Ok(out) => {
+                tracing::warn!(
+                    "[dispute_yaml] '{}' — gh issue create failed (exit {}): {}",
+                    test_id,
+                    out.status,
+                    String::from_utf8_lossy(&out.stderr).trim()
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "[dispute_yaml] '{}' — gh CLI not available or spawn failed: {e}",
+                    test_id
+                );
+            }
+        }
+    }
+
+    dispute
+}
+
 // ── Public types ─────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -297,11 +443,33 @@ pub struct TestResult {
     pub screenshot_error: Option<String>,
     pub history: Vec<TestStep>,
     pub final_analysis: Option<String>,
+    /// Populated when `status == Disputed` — carries the LLM-supplied
+    /// dispute payload from the `dispute_yaml` action.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dispute: Option<DisputeInfo>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub enum TestStatus { Passed, Failed, Timeout, Error }
+pub enum TestStatus {
+    Passed,
+    Failed,
+    Timeout,
+    Error,
+    /// LLM identified a YAML/spec issue and called `dispute_yaml`.
+    /// Not a test failure — a signal that the spec needs human review.
+    /// Sirin auto-opens a GitHub issue and writes a KB entry.
+    Disputed,
+}
+
+/// Dispute metadata written when `dispute_yaml` action fires.
+/// All fields are LLM-provided and informational only — never auto-acted on.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DisputeInfo {
+    pub reason: String,
+    pub suspected_step: Option<i64>,
+    pub suggested_fix: Option<String>,
+}
 
 // ── Executor ─────────────────────────────────────────────────────────────────
 
@@ -674,6 +842,7 @@ pub async fn execute_test_tracked(
                     screenshot_error: cap.error,
                     history,
                     final_analysis: None,
+                    dispute: None,
                 };
             }
 
@@ -803,6 +972,7 @@ pub async fn execute_test_tracked(
                     screenshot_error: cap.error,
                     history,
                     final_analysis: Some(analysis.reason),
+                    dispute: None,
                 };
             }
 
@@ -825,6 +995,68 @@ pub async fn execute_test_tracked(
                     crate::browser::show_action_indicator(&label);
                 }).await;
             }
+            // Issue #103: `dispute_yaml` — LLM signals that the YAML spec has
+            // a bug.  Terminate the loop immediately with Disputed status.
+            // Side-effects: KB write + gh issue create (both fire-and-forget).
+            if action_label == "dispute_yaml" {
+                let reason = action_input
+                    .get("reason")
+                    .and_then(Value::as_str)
+                    .unwrap_or("(no reason provided)")
+                    .to_string();
+                let suspected_step = action_input
+                    .get("suspected_step")
+                    .and_then(Value::as_i64);
+                let suggested_fix = action_input
+                    .get("suggested_fix")
+                    .and_then(Value::as_str)
+                    .map(String::from);
+                let dispute_info = DisputeInfo { reason: reason.clone(), suspected_step, suggested_fix };
+
+                // Capture URL for context (best-effort; ignore errors).
+                let final_url = ctx.call_tool("web_navigate", json!({"action":"url"})).await
+                    .ok()
+                    .and_then(|v| v.get("url").and_then(Value::as_str).map(String::from))
+                    .unwrap_or_default();
+
+                let dispute_out = handle_dispute_yaml(
+                    &test.id,
+                    run_id,
+                    iteration,
+                    dispute_info,
+                    &final_url,
+                    &llm_model,
+                );
+
+                // Push a trace step so the dispute is visible in the history.
+                let obs = format!("[dispute_yaml] reason: {reason}");
+                if let Some(rid) = run_id {
+                    runs::push_observation(rid, obs.clone());
+                }
+                let mut s = TestStep {
+                    thought: step.thought,
+                    action: action_input.clone(),
+                    observation: obs,
+                    ..Default::default()
+                };
+                trace_stamp(&mut s, parse_error_count);
+                history.push(s);
+
+                let cap = capture_screenshot(ctx, &test.id, run_id).await;
+                break 'react TestResult {
+                    test_id: test.id.clone(),
+                    status: TestStatus::Disputed,
+                    iterations: iteration + 1,
+                    duration_ms: started.elapsed().as_millis() as u64,
+                    error_message: Some(format!("dispute_yaml: {}", dispute_out.reason)),
+                    screenshot_path: cap.path,
+                    screenshot_error: cap.error,
+                    history,
+                    final_analysis: Some(format!("LLM disputed YAML spec at iteration {iteration}")),
+                    dispute: Some(dispute_out),
+                };
+            }
+
             // Dispatch to the appropriate tool.  `expand_observation` is a
             // meta-tool (reads run registry, no browser action).  Everything else
             // goes through `web_navigate`.
@@ -1027,6 +1259,7 @@ pub async fn execute_test_tracked(
             screenshot_error: cap.error,
             history,
             final_analysis: None,
+            dispute: None,
         }
     };  // end 'react block
 
@@ -1083,6 +1316,7 @@ async fn finalize_early(
         screenshot_error: cap.error,
         history: history.to_vec(),
         final_analysis: None,
+        dispute: None,
     }
 }
 
@@ -1431,6 +1665,22 @@ you can fetch the complete content by outputting an action that calls the
 `expand_observation` tool directly (not via web_navigate):
   {{"action": "expand_observation", "step": N}}
 Where N is the 0-indexed step number from the truncation hint.
+
+## dispute_yaml — 回報 YAML spec 問題（標準動作，非失敗）
+當你發現 YAML spec 本身有問題時，呼叫：
+  {{"action": "dispute_yaml", "reason": "<原因>", "suspected_step": <步驟編號或 null>, "suggested_fix": "<修正建議或 null>"}}
+
+**何時呼叫 dispute_yaml：**
+1. 你執行某 step 後預期 page 變化，但畫面沒變 → 先 retry 1 次再 dispute
+2. screenshot 顯示你**已經在 step 預設要去的目的地**（例如 step 2 說「切到商品頁」但你已在商品頁）
+3. element name_regex 跟畫面上實際 button label 明顯不符
+4. step 順序邏輯不通（例如 step N 需要 step M 的產出但 M 沒做到）
+
+**不要 dispute：**
+- 因為 element 暫時找不到（先 retry 1 次）
+- 因為 LLM 自己判斷不出來（dispute 要明確指出哪個 step 哪裡錯）
+
+dispute_yaml 不是失敗——是回報 spec 問題的標準動作。Sirin 會自動開 GitHub issue 給維護者。
 
 ## History
 {history}
@@ -2148,5 +2398,99 @@ mod tests {
         assert!(!is_error_observation(r#"{"ax_node_count":39}"#));
         assert!(!is_error_observation(""));
         assert!(!is_error_observation("Some unrelated text"));
+    }
+
+    // ── Issue #103: dispute_yaml ─────────────────────────────────────────────
+
+    /// `parse_step` must accept a `dispute_yaml` action without parse error.
+    /// The action has three optional fields in addition to "action".
+    #[test]
+    fn dispute_yaml_parses_correctly() {
+        let raw = r#"{
+            "thought": "Step 2 already on target page — spec is wrong",
+            "action_input": {
+                "action": "dispute_yaml",
+                "reason": "step 2 商品 tab 已 selected，click 沒反應",
+                "suspected_step": 2,
+                "suggested_fix": "改成 conditional: if not on page, click"
+            },
+            "done": false
+        }"#;
+        let s = parse_step(raw);
+        assert!(s.parse_error.is_none(), "dispute_yaml should parse cleanly: {:?}", s.parse_error);
+        assert_eq!(s.action_input["action"], "dispute_yaml");
+        assert_eq!(s.action_input["suspected_step"], 2);
+        assert!(!s.done, "dispute_yaml should not set done=true via parse_step");
+    }
+
+    /// `dispute_yaml` without optional fields (reason only) must also parse.
+    #[test]
+    fn dispute_yaml_parses_reason_only() {
+        let raw = r#"{"thought":"x","action_input":{"action":"dispute_yaml","reason":"element missing"},"done":false}"#;
+        let s = parse_step(raw);
+        assert!(s.parse_error.is_none());
+        assert_eq!(s.action_input["action"], "dispute_yaml");
+        // suspected_step absent → Value::Null
+        assert!(s.action_input.get("suspected_step").map_or(true, |v| v.is_null()));
+    }
+
+    /// `DisputeInfo` deserialized from `action_input` must carry the correct fields.
+    #[test]
+    fn dispute_info_extracts_fields_correctly() {
+        let action_input = json!({
+            "action": "dispute_yaml",
+            "reason": "step 3 already on destination",
+            "suspected_step": 3,
+            "suggested_fix": "remove step 3 or add condition"
+        });
+        let reason = action_input.get("reason").and_then(Value::as_str)
+            .unwrap_or("").to_string();
+        let suspected_step = action_input.get("suspected_step").and_then(Value::as_i64);
+        let suggested_fix = action_input.get("suggested_fix").and_then(Value::as_str)
+            .map(String::from);
+        let di = DisputeInfo { reason: reason.clone(), suspected_step, suggested_fix };
+
+        assert_eq!(di.reason, "step 3 already on destination");
+        assert_eq!(di.suspected_step, Some(3));
+        assert_eq!(di.suggested_fix.as_deref(), Some("remove step 3 or add condition"));
+    }
+
+    /// `handle_dispute_yaml` returns a `DisputeInfo` with the reason intact
+    /// and does NOT panic when KB and gh CLI are unavailable.
+    ///
+    /// KB write is async fire-and-forget and KB_ENABLED defaults to false in
+    /// tests.  gh CLI invocation may fail (not installed in CI) — the function
+    /// must log a warning and continue rather than panicking.
+    #[test]
+    fn dispute_yaml_handle_is_non_panicking() {
+        // Tokio runtime needed for the fire-and-forget KB spawn inside.
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let info = DisputeInfo {
+                reason: "unit-test dispute reason".into(),
+                suspected_step: Some(1),
+                suggested_fix: Some("test fix".into()),
+            };
+            // No run_id — tests that gh CLI may be missing; should not panic.
+            let out = handle_dispute_yaml(
+                "test_dispute_non_panic",
+                Some("run_test_123"),
+                0,
+                info,
+                "https://example.com",
+                "gemini-test",
+            );
+            assert_eq!(out.reason, "unit-test dispute reason");
+            assert_eq!(out.suspected_step, Some(1));
+        });
+    }
+
+    /// `TestStatus::Disputed` round-trips through serde_json.
+    #[test]
+    fn test_status_disputed_serializes_as_lowercase() {
+        let s = serde_json::to_string(&TestStatus::Disputed).unwrap();
+        assert_eq!(s, r#""disputed""#);
+        let back: TestStatus = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, TestStatus::Disputed);
     }
 }

--- a/src/test_runner/mod.rs
+++ b/src/test_runner/mod.rs
@@ -165,10 +165,11 @@ async fn run_test_with_run_id(
         started_at: &started,
         duration_ms: Some(result.duration_ms as i64),
         status: match result.status {
-            TestStatus::Passed  => "passed",
-            TestStatus::Failed  => "failed",
-            TestStatus::Timeout => "timeout",
-            TestStatus::Error   => "error",
+            TestStatus::Passed   => "passed",
+            TestStatus::Failed   => "failed",
+            TestStatus::Timeout  => "timeout",
+            TestStatus::Error    => "error",
+            TestStatus::Disputed => "disputed",
         },
         failure_category: category.as_deref(),
         ai_analysis: analysis.as_deref(),
@@ -177,6 +178,9 @@ async fn run_test_with_run_id(
         goal_json: goal_json.as_deref(),
         run_id,
         iterations: Some(result.iterations),
+        dispute_reason: result.dispute.as_ref().map(|d| d.reason.as_str()),
+        dispute_suspected_step: result.dispute.as_ref().and_then(|d| d.suspected_step),
+        dispute_suggested_fix: result.dispute.as_ref().and_then(|d| d.suggested_fix.as_deref()),
     });
 
     if fix_triggered {
@@ -307,10 +311,11 @@ pub fn spawn_adhoc_run(req: AdhocRunRequest) -> Result<String, String> {
             // Persist to SQLite — ad-hoc runs are still worth recording
             let history_json = serde_json::to_string(&result.history).ok();
             let status_str = match result.status {
-                TestStatus::Passed  => "passed",
-                TestStatus::Failed  => "failed",
-                TestStatus::Timeout => "timeout",
-                TestStatus::Error   => "error",
+                TestStatus::Passed   => "passed",
+                TestStatus::Failed   => "failed",
+                TestStatus::Timeout  => "timeout",
+                TestStatus::Error    => "error",
+                TestStatus::Disputed => "disputed",
             };
             // Persist the goal too so persist_adhoc_run can recover after
             // the in-memory run state is pruned (1 hour TTL).
@@ -327,6 +332,9 @@ pub fn spawn_adhoc_run(req: AdhocRunRequest) -> Result<String, String> {
                 goal_json: goal_json.as_deref(),
                 run_id: Some(&run_id_clone),
                 iterations: Some(result.iterations),
+                dispute_reason: result.dispute.as_ref().map(|d| d.reason.as_str()),
+                dispute_suspected_step: result.dispute.as_ref().and_then(|d| d.suspected_step),
+                dispute_suggested_fix: result.dispute.as_ref().and_then(|d| d.suggested_fix.as_deref()),
             });
 
             runs::set_phase(&run_id_clone, runs::RunPhase::Complete(result));
@@ -479,10 +487,11 @@ pub fn spawn_batch_run(
                 // Persist to SQLite — same shape as spawn_run_async.
                 let history_json = serde_json::to_string(&result.history).ok();
                 let status_str = match result.status {
-                    TestStatus::Passed  => "passed",
-                    TestStatus::Failed  => "failed",
-                    TestStatus::Timeout => "timeout",
-                    TestStatus::Error   => "error",
+                    TestStatus::Passed   => "passed",
+                    TestStatus::Failed   => "failed",
+                    TestStatus::Timeout  => "timeout",
+                    TestStatus::Error    => "error",
+                    TestStatus::Disputed => "disputed",
                 };
                 let goal_json = serde_json::to_string(&test).ok();
                 let _ = store::record_run(store::NewRun {
@@ -497,6 +506,9 @@ pub fn spawn_batch_run(
                     goal_json: goal_json.as_deref(),
                     run_id: Some(&run_id_clone),
                     iterations: Some(result.iterations),
+                    dispute_reason: result.dispute.as_ref().map(|d| d.reason.as_str()),
+                    dispute_suspected_step: result.dispute.as_ref().and_then(|d| d.suspected_step),
+                    dispute_suggested_fix: result.dispute.as_ref().and_then(|d| d.suggested_fix.as_deref()),
                 });
 
                 let passed = matches!(result.status, TestStatus::Passed);
@@ -829,6 +841,7 @@ mod persist_tests {
             final_analysis: None,
             screenshot_path: None,
             screenshot_error: None,
+            dispute: None,
         };
         runs::set_phase(&run_id, runs::RunPhase::Complete(fake_result));
         run_id
@@ -1005,6 +1018,9 @@ mod persist_tests {
             goal_json: Some(&goal_json_str),
             run_id: Some(&synthetic_run_id),
             iterations: Some(6),
+            dispute_reason: None,
+            dispute_suspected_step: None,
+            dispute_suggested_fix: None,
         }).unwrap();
 
         // NOTE: we deliberately do NOT call runs::new_run() — the in-memory

--- a/src/test_runner/runs.rs
+++ b/src/test_runner/runs.rs
@@ -370,10 +370,11 @@ pub fn to_json(s: &RunState) -> serde_json::Value {
         ),
         RunPhase::Complete(r) => (
             match r.status {
-                TestStatus::Passed  => "passed",
-                TestStatus::Failed  => "failed",
-                TestStatus::Timeout => "timeout",
-                TestStatus::Error   => "error",
+                TestStatus::Passed   => "passed",
+                TestStatus::Failed   => "failed",
+                TestStatus::Timeout  => "timeout",
+                TestStatus::Error    => "error",
+                TestStatus::Disputed => "disputed",
             },
             json!({
                 "iterations": r.iterations,

--- a/src/test_runner/store.rs
+++ b/src/test_runner/store.rs
@@ -80,6 +80,11 @@ fn db() -> &'static Mutex<rusqlite::Connection> {
         let _ = conn.execute("ALTER TABLE test_runs ADD COLUMN goal_json TEXT", []);
         let _ = conn.execute("ALTER TABLE test_runs ADD COLUMN run_id TEXT", []);
         let _ = conn.execute("ALTER TABLE test_runs ADD COLUMN iterations INTEGER", []);
+        // Migration: Issue #103 — dispute_yaml action.  Three nullable columns
+        // for the LLM-supplied dispute metadata written when status='disputed'.
+        let _ = conn.execute("ALTER TABLE test_runs ADD COLUMN dispute_reason TEXT", []);
+        let _ = conn.execute("ALTER TABLE test_runs ADD COLUMN dispute_suspected_step INTEGER", []);
+        let _ = conn.execute("ALTER TABLE test_runs ADD COLUMN dispute_suggested_fix TEXT", []);
         let _ = conn.execute("CREATE INDEX IF NOT EXISTS idx_tr_runid ON test_runs(run_id)", []);
         // Single-column index on `started_at` for `recent_runs_all` —
         // Test Dashboard polls `ORDER BY started_at DESC LIMIT 30` every 3s.
@@ -130,18 +135,28 @@ pub struct NewRun<'a> {
     /// Iterations actually consumed.  Stored separately from
     /// history_json for cheap aggregate queries.
     pub iterations: Option<u32>,
+    // ── Issue #103: dispute_yaml fields ─────────────────────────────────────
+    /// LLM-supplied reason for the YAML spec dispute.  Only set when
+    /// status = "disputed".  Stored verbatim — never auto-acted on.
+    pub dispute_reason: Option<&'a str>,
+    /// Step index the LLM suspects is incorrect (0-based, LLM-supplied).
+    pub dispute_suspected_step: Option<i64>,
+    /// LLM-supplied suggestion for fixing the YAML step (informational only).
+    pub dispute_suggested_fix: Option<&'a str>,
 }
 
 pub fn record_run(r: NewRun<'_>) -> Result<i64, String> {
     let conn = db().lock().unwrap_or_else(|e| e.into_inner());
     conn.execute(
         "INSERT INTO test_runs(test_id, started_at, duration_ms, status, failure_category, \
-                               ai_analysis, screenshot_path, history_json, goal_json, run_id, iterations) \
-         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11)",
+                               ai_analysis, screenshot_path, history_json, goal_json, run_id, \
+                               iterations, dispute_reason, dispute_suspected_step, dispute_suggested_fix) \
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14)",
         rusqlite::params![
             r.test_id, r.started_at, r.duration_ms, r.status,
             r.failure_category, r.ai_analysis, r.screenshot_path, r.history_json,
             r.goal_json, r.run_id, r.iterations,
+            r.dispute_reason, r.dispute_suspected_step, r.dispute_suggested_fix,
         ],
     ).map_err(|e| format!("insert run: {e}"))?;
     let row_id = conn.last_insert_rowid();
@@ -570,6 +585,9 @@ mod tests {
                 goal_json: None,
                 run_id: None,
                 iterations: None,
+                dispute_reason: None,
+                dispute_suspected_step: None,
+                dispute_suggested_fix: None,
             }).unwrap();
             // Small delay so started_at ordering is deterministic
             std::thread::sleep(std::time::Duration::from_millis(2));
@@ -595,6 +613,9 @@ mod tests {
             goal_json: Some(goal_json),
             run_id: Some(&rid),
             iterations: Some(7),
+            dispute_reason: None,
+            dispute_suspected_step: None,
+            dispute_suggested_fix: None,
         }).unwrap();
         let recovered = find_run_by_run_id(&rid).expect("must find by run_id");
         assert_eq!(recovered.0, goal_json);
@@ -813,5 +834,40 @@ mod tests {
         store_knowledge(&tid, "selector_login", "button[aria-label=登入]").unwrap();
         assert_eq!(get_knowledge(&tid, "selector_login"), Some("button[aria-label=登入]".into()));
         assert_eq!(get_knowledge(&tid, "nonexistent"), None);
+    }
+
+    // ── Issue #103: dispute_yaml storage ──────────────────────────────────────
+
+    /// `record_run` with status="disputed" and dispute fields must round-trip
+    /// cleanly — the row is retrievable by `find_run_by_run_id` with the
+    /// "disputed" status string preserved.
+    #[test]
+    fn dispute_yaml_fields_stored_and_retrieved() {
+        let unique = chrono::Local::now().timestamp_nanos_opt().unwrap_or(0);
+        let tid = format!("dispute_store_{unique}");
+        let rid = format!("run_dispute_{unique}");
+        let now = chrono::Local::now().to_rfc3339();
+
+        record_run(NewRun {
+            test_id: &tid,
+            started_at: &now,
+            duration_ms: Some(5000),
+            status: "disputed",
+            failure_category: Some("yaml_spec"),
+            ai_analysis: Some("LLM reported YAML step 2 impossible"),
+            screenshot_path: None,
+            history_json: None,
+            goal_json: Some(r#"{"id":"t","goal":"g"}"#),
+            run_id: Some(&rid),
+            iterations: Some(3),
+            dispute_reason: Some("Step 2 already on target page, click has no effect"),
+            dispute_suspected_step: Some(2),
+            dispute_suggested_fix: Some("Add conditional: if not on page, navigate"),
+        }).unwrap();
+
+        // Verify the run_id lookup returns status "disputed" — that's what
+        // `get_test_result` surfaces via the in-memory registry's TestStatus::Disputed.
+        let (_, status, _) = find_run_by_run_id(&rid).expect("must find disputed run by run_id");
+        assert_eq!(status, "disputed");
     }
 }


### PR DESCRIPTION
## Summary

- **Layer 1**: ReAct loop 識別 `dispute_yaml` action → 立即終止 loop，返回 `TestStatus::Disputed`（跟 Passed/Failed/Error 並列）
- **Layer 2**: auto kbWrite — 寫 `yaml-dispute-{test_id}-{run_id}` draft note（KB_ENABLED=1 時）
- **Layer 3**: auto `gh issue create` — labels=`yaml-dispute,bot-flagged,triage`，body 含 test_id / run_id / LLM / reason / step / fix / URL

## 改動檔案

| 檔案 | 改動 |
|---|---|
| `src/test_runner/executor.rs` | `DisputeInfo` struct + `TestStatus::Disputed` + `handle_dispute_yaml()` + ReAct loop intercept + LLM prompt (中文規則) |
| `src/test_runner/store.rs` | `dispute_reason` / `dispute_suspected_step` / `dispute_suggested_fix` 欄位 + migration ALTER TABLE + `NewRun` 更新 |
| `src/test_runner/mod.rs` | `TestStatus::Disputed` match arm (3 處) + `dispute` 欄位傳遞 |
| `src/test_runner/runs.rs` | `TestStatus::Disputed` → `"disputed"` |
| `src/skills.rs` | `TestStatus::Disputed` → `"⚠ DISPUTED"` label |

## Unit tests (6 新增)

1. `dispute_yaml_parses_correctly` — parse_step 正確解析 dispute_yaml action
2. `dispute_yaml_parses_reason_only` — 只有 reason 也正確
3. `dispute_info_extracts_fields_correctly` — DisputeInfo 欄位提取
4. `dispute_yaml_handle_is_non_panicking` — gh CLI 不存在不崩潰
5. `test_status_disputed_serializes_as_lowercase` — serde round-trip
6. `dispute_yaml_fields_stored_and_retrieved` (store.rs) — SQLite 欄位儲存

## Test plan

- [ ] `cargo check --bin sirin` → 0 errors ✅
- [ ] `cargo test --bin sirin -- dispute` → 6/6 pass ✅
- [ ] `cargo test --bin sirin` → 581 pass, 1 pre-existing YAML fail (agora_pickup_time_picker.yaml in working tree — unrelated) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)