### PR TITLE
feat(llm): vision specialist LLM routing for screenshot_analyze (Closes #107)

### DIFF
--- a/src/adk/tool/builtins.rs
+++ b/src/adk/tool/builtins.rs
@@ -1358,21 +1358,30 @@ pub(super) fn build_full_registry() -> ToolRegistry {
                 }
 
                 if analysis.is_none() {
-                    let llm = crate::llm::shared_llm();
+                    // Use the vision specialist LLM if configured via
+                    // LLM_VISION_BACKEND / LLM_VISION_BASE_URL / LLM_VISION_MODEL /
+                    // LLM_VISION_API_KEY; fall back to the main LLM when any var
+                    // is absent (backward-compatible, zero behaviour change).
+                    let vision_cfg = crate::llm::vision_llm_config();
+                    let main_llm = crate::llm::shared_llm();
+                    let llm_for_vision: &crate::llm::LlmConfig = match vision_cfg.as_ref() {
+                        Some(v) => v,
+                        None    => &main_llm,
+                    };
                     let client = crate::llm::shared_http();
                     // Use call_vision directly with the already-captured b64
                     // so we don't trigger analyze_screenshot's internal
                     // browser::screenshot() (the 4th capture pre-fix).
                     let vision_res = if !png_b64_inline.is_empty() {
                         crate::llm::call_vision(
-                            &client, &llm, &prompt_with_directive,
+                            &client, llm_for_vision, &prompt_with_directive,
                             &png_b64_inline, "image/png",
                         ).await
                     } else {
                         // Fallback: blocking_fut didn't pass png_b64 (e.g.
                         // older code path); legacy analyze_screenshot path
                         // still works but does its own capture.
-                        crate::llm::analyze_screenshot(&client, &llm, &prompt_with_directive).await
+                        crate::llm::analyze_screenshot(&client, llm_for_vision, &prompt_with_directive).await
                     };
                     match vision_res {
                         Ok(res) => {

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -467,6 +467,50 @@ impl LlmConfig {
     }
 }
 
+// ── Vision specialist LLM config ─────────────────────────────────────────────
+
+/// Build an `LlmConfig` for vision-only calls (e.g. `screenshot_analyze`).
+///
+/// Reads four env vars:
+/// - `LLM_VISION_BACKEND`  — `ollama` | `lmstudio` | `gemini` | `anthropic`
+/// - `LLM_VISION_BASE_URL` — endpoint base URL
+/// - `LLM_VISION_MODEL`    — model name (e.g. `qwen/qwen2.5-vl-7b-instruct`)
+/// - `LLM_VISION_API_KEY`  — Bearer token
+///
+/// Returns `Some(LlmConfig)` only when **all four** are present and non-empty;
+/// returns `None` otherwise so callers fall back to the main LLM without change.
+pub fn vision_llm_config() -> Option<LlmConfig> {
+    let backend_str = std::env::var("LLM_VISION_BACKEND")
+        .ok()
+        .filter(|v| !v.trim().is_empty())?;
+    let base_url = std::env::var("LLM_VISION_BASE_URL")
+        .ok()
+        .filter(|v| !v.trim().is_empty())?;
+    let model = std::env::var("LLM_VISION_MODEL")
+        .ok()
+        .filter(|v| !v.trim().is_empty())?;
+    let api_key = std::env::var("LLM_VISION_API_KEY")
+        .ok()
+        .filter(|v| !v.trim().is_empty())?;
+
+    let backend = match backend_str.to_lowercase().as_str() {
+        "lmstudio" | "lm_studio" | "openai" => LlmBackend::LmStudio,
+        "gemini" | "google" => LlmBackend::Gemini,
+        "anthropic" | "claude" => LlmBackend::Anthropic,
+        _ => LlmBackend::Ollama,
+    };
+
+    Some(LlmConfig {
+        backend,
+        base_url,
+        model,
+        api_key: Some(api_key),
+        coding_model: None,
+        router_model: None,
+        large_model: None,
+    })
+}
+
 // ── Public message types ──────────────────────────────────────────────────────
 
 /// Role of a participant in a multi-turn conversation.
@@ -879,5 +923,49 @@ mod tests {
         assert_eq!(usr.role, MessageRole::User);
         assert_eq!(ast.role, MessageRole::Assistant);
         assert_eq!(usr.content, "hello");
+    }
+
+    // ── vision_llm_config ─────────────────────────────────────────────────────
+
+    #[test]
+    fn vision_llm_config_reads_env_vars() {
+        // Scope env-var changes so they don't leak into other tests.
+        // (Tests within the same binary share the process environment.)
+        std::env::set_var("LLM_VISION_BACKEND",  "lmstudio");
+        std::env::set_var("LLM_VISION_BASE_URL", "https://openrouter.ai/api/v1");
+        std::env::set_var("LLM_VISION_MODEL",    "qwen/qwen2.5-vl-7b-instruct");
+        std::env::set_var("LLM_VISION_API_KEY",  "sk-test-key");
+
+        let cfg = super::vision_llm_config();
+
+        // Cleanup before any assert (so a failing assert doesn't leave vars set).
+        std::env::remove_var("LLM_VISION_BACKEND");
+        std::env::remove_var("LLM_VISION_BASE_URL");
+        std::env::remove_var("LLM_VISION_MODEL");
+        std::env::remove_var("LLM_VISION_API_KEY");
+
+        let cfg = cfg.expect("should return Some when all four vars are set");
+        assert_eq!(cfg.backend, LlmBackend::LmStudio);
+        assert_eq!(cfg.base_url, "https://openrouter.ai/api/v1");
+        assert_eq!(cfg.model, "qwen/qwen2.5-vl-7b-instruct");
+        assert_eq!(cfg.api_key.as_deref(), Some("sk-test-key"));
+    }
+
+    #[test]
+    fn vision_llm_config_returns_none_if_incomplete() {
+        // Only set three of the four required vars — should return None.
+        std::env::set_var("LLM_VISION_BACKEND",  "gemini");
+        std::env::set_var("LLM_VISION_BASE_URL", "https://example.com");
+        std::env::set_var("LLM_VISION_MODEL",    "gemini-vision");
+        // LLM_VISION_API_KEY intentionally omitted.
+        std::env::remove_var("LLM_VISION_API_KEY");
+
+        let result = super::vision_llm_config();
+
+        std::env::remove_var("LLM_VISION_BACKEND");
+        std::env::remove_var("LLM_VISION_BASE_URL");
+        std::env::remove_var("LLM_VISION_MODEL");
+
+        assert!(result.is_none(), "should return None when API key is missing");
     }
 }

--- a/src/test_runner/executor.rs
+++ b/src/test_runner/executor.rs
@@ -594,6 +594,19 @@ pub async fn execute_test_tracked(
         runs::set_phase(rid, runs::RunPhase::Running { step: 0, current_action: "goto".into() });
     }
 
+    // Vision specialist startup log (once per test, not per iteration).
+    match crate::llm::vision_llm_config() {
+        Some(ref v) => tracing::info!(
+            target: "sirin",
+            "[llm] vision specialist: backend={:?} model={}",
+            v.backend, v.model
+        ),
+        None => tracing::info!(
+            target: "sirin",
+            "[llm] vision specialist: (none, using main model)"
+        ),
+    }
+
     // 0-pre) Resolve docs_refs into a Markdown block the prompt builders can
     // splice in.  Each entry is read from disk (filesystem path) or fetched
     // from the central KB (topicKey).  Cached per test_id for the duration


### PR DESCRIPTION
## Summary

- Add `vision_llm_config() -> Option<LlmConfig>` to `src/llm/mod.rs`: reads `LLM_VISION_BACKEND` / `LLM_VISION_BASE_URL` / `LLM_VISION_MODEL` / `LLM_VISION_API_KEY`; returns `Some` only when all four are set, `None` otherwise
- Update `src/adk/tool/builtins.rs` `screenshot_analyze` dispatch: use vision specialist LLM when configured, fall back to `shared_llm()` when any var is absent (zero behaviour change for existing setups)
- Add startup log in `src/test_runner/executor.rs` (once per test, not per iteration): logs which model is active for vision calls
- Add two unit tests: `vision_llm_config_reads_env_vars` and `vision_llm_config_returns_none_if_incomplete`

## Test plan

- [x] `cargo check --bin sirin` — 0 errors
- [x] `cargo test --bin sirin -- vision_llm` — 2 passed, 0 failed
- [x] `LLM_VISION_*` all set → vision specialist used for `screenshot_analyze`, startup log shows model name
- [x] `LLM_VISION_*` unset → fallback to main LLM, behaviour unchanged (backward compat)
- [x] Only `screenshot_analyze` is routed; all other actions unchanged
- [x] `call_vision()` bottom-layer signature untouched

## Usage example (after merge)

```bash
# %LOCALAPPDATA%\Sirin\.env

# Main reasoning (text-only, free Groq)
LLM_PROVIDER=lmstudio
LM_STUDIO_BASE_URL=https://api.groq.com/openai/v1
LM_STUDIO_MODEL=llama-3.3-70b-versatile
LM_STUDIO_API_KEY=gsk_...

# Vision specialist (screenshot_analyze only)
LLM_VISION_BACKEND=lmstudio
LLM_VISION_BASE_URL=https://openrouter.ai/api/v1
LLM_VISION_MODEL=qwen/qwen2.5-vl-7b-instruct
LLM_VISION_API_KEY=sk-or-...
```

~$0.005/test vs $0.10 for full 72B — 20× cheaper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)