### PR TITLE
fix(llm): warn when VISION_API_KEY empty + executor vision-fallback strategy (Closes #109)

### DIFF
--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -489,9 +489,20 @@ pub fn vision_llm_config() -> Option<LlmConfig> {
     let model = std::env::var("LLM_VISION_MODEL")
         .ok()
         .filter(|v| !v.trim().is_empty())?;
-    let api_key = std::env::var("LLM_VISION_API_KEY")
-        .ok()
-        .filter(|v| !v.trim().is_empty())?;
+
+    // Warn explicitly when base_url is set but api_key is missing, so the user
+    // gets a clear signal that the vision specialist will be silently disabled.
+    let raw_api_key = std::env::var("LLM_VISION_API_KEY").unwrap_or_default();
+    if raw_api_key.trim().is_empty() {
+        tracing::warn!(
+            target: "sirin",
+            "[llm] LLM_VISION_BASE_URL is set ({}) but LLM_VISION_API_KEY is empty — \
+             vision specialist DISABLED. All screenshot_analyze calls will use the main LLM.",
+            base_url
+        );
+        return None;
+    }
+    let api_key = raw_api_key;
 
     let backend = match backend_str.to_lowercase().as_str() {
         "lmstudio" | "lm_studio" | "openai" => LlmBackend::LmStudio,
@@ -967,5 +978,30 @@ mod tests {
         std::env::remove_var("LLM_VISION_MODEL");
 
         assert!(result.is_none(), "should return None when API key is missing");
+    }
+
+    #[test]
+    fn vision_llm_config_warns_when_base_url_set_but_key_empty() {
+        // Arrange: base_url + backend + model are set, but api_key is empty string.
+        std::env::set_var("LLM_VISION_BACKEND",  "lmstudio");
+        std::env::set_var("LLM_VISION_BASE_URL", "https://openrouter.ai/api/v1");
+        std::env::set_var("LLM_VISION_MODEL",    "qwen/qwen2.5-vl-7b-instruct");
+        std::env::set_var("LLM_VISION_API_KEY",  "");
+
+        let result = super::vision_llm_config();
+
+        // Cleanup before assertions so env doesn't leak on failure.
+        std::env::remove_var("LLM_VISION_BACKEND");
+        std::env::remove_var("LLM_VISION_BASE_URL");
+        std::env::remove_var("LLM_VISION_MODEL");
+        std::env::remove_var("LLM_VISION_API_KEY");
+
+        // The function must return None (vision specialist disabled) when
+        // LLM_VISION_API_KEY is set but empty — the warning is emitted inside
+        // the function; we just assert the observable return value here.
+        assert!(
+            result.is_none(),
+            "should return None and warn when base_url is set but api_key is empty"
+        );
     }
 }

--- a/src/test_runner/executor.rs
+++ b/src/test_runner/executor.rs
@@ -1658,6 +1658,17 @@ Fallback to ax_find/ax_click if shadow_find returns "no shadow root".
 When you need EXACT text comparison (numbers, IDs), prefer ax_* over
 screenshot_analyze (which approximates).
 
+## 當 shadow_dump 找不到目標時的替代策略（重要）
+
+連續 2 次 shadow_dump 仍找不到目標元素時，立刻切換到 Vision-Coordinate 策略：
+
+1. screenshot_analyze "找 <目標元素> 的螢幕位置，估計中心 x, y 座標（viewport pixel）"
+2. click_point x=<估計值> y=<估計值> coord_source=screenshot
+
+⚠️ 不要在同一頁面 shadow_dump 超過 2 次。
+截圖可以直接看到 Flutter canvas 上的 UI，比 AX tree 更直接。
+click_point coord_source=screenshot 會自動修正 HiDPI 縮放。
+
 ## Robustness actions (test isolation + race-free)
 - go_back        — browser history back 1 step + waits for Flutter AX tree to settle (≥10 nodes, 8 s)
                    optional param: wait (extra ms after AX ready, e.g. {{"action":"go_back","wait":2000}})


### PR DESCRIPTION
## Summary

- **executor.rs**: 在 shadow DOM 說明區塊後加入「Vision-Coordinate 替代策略」提示 — 當連續 2 次 `shadow_dump` 找不到目標元素時，agent 應切換為 `screenshot_analyze` + `click_point coord_source=screenshot`，避免同頁面無限 shadow_dump 迴圈。
- **llm/mod.rs**: `vision_llm_config()` 新增顯式 warn — 當 `LLM_VISION_BASE_URL` 有設定但 `LLM_VISION_API_KEY` 為空時，用 `tracing::warn!` 告知使用者 vision specialist 已停用，然後 return None（原本是靜默 return None，使用者無法得知原因）。
- **llm/mod.rs test**: 加入 `vision_llm_config_warns_when_base_url_set_but_key_empty` — 設定空 API key，斷言回傳 None。

## Test plan

- [x] `cargo check --bin sirin` → 0 errors
- [x] `cargo test --bin sirin -- vision_llm_config` → 3 passed (reads_env_vars, returns_none_if_incomplete, warns_when_base_url_set_but_key_empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)