### PR TITLE
fix(browser_ax): wait_for_ax_ready guard + poll_tree_recovery retries + prompt anti-pattern

### DIFF
--- a/src/browser_ax.rs
+++ b/src/browser_ax.rs
@@ -187,8 +187,9 @@ pub fn get_full_tree(include_ignored: bool) -> Result<Vec<AxNode>, String> {
     if raw_node_count(&tree) <= 2 {
         // Wait for potential post-navigation transient teardown to resolve.
         // Flutter rebuilds the Semantics tree after SPA route changes; the
-        // window is usually 300-800ms.  3 × 400ms = 1.2s covers it.
-        if !poll_tree_recovery(3, 400) {
+        // window can take up to 3 s on slow Flutter builds.
+        // 6 × 600ms = 3.6s covers the extended recovery window.
+        if !poll_tree_recovery(6, 600) {
             // Still tiny — attempt bootstrap (A/B; Tab×2 removed, see Issue #20).
             let _ = enable_flutter_semantics();
             std::thread::sleep(std::time::Duration::from_millis(400));
@@ -344,6 +345,21 @@ fn json_ax_value(node: &serde_json::Value, field: &str) -> Option<String> {
 /// {"action":"wait_for_ax_ready","min_nodes":20,"timeout":10000}
 /// ```
 pub fn wait_for_ax_ready(min_nodes: usize, timeout_ms: u64) -> Result<(u64, usize), String> {
+    // Guard: if enable_a11y was never called for this tab, the semantics tree
+    // will never be initialized — fail immediately instead of waiting out the
+    // full timeout (which would always be wasted time, typically 30 s).
+    let active = crate::browser::active_tab().unwrap_or(0);
+    {
+        let set = a11y_tabs().lock().unwrap_or_else(|e| e.into_inner());
+        if !set.contains(&active) {
+            return Err(format!(
+                "wait_for_ax_ready called before enable_a11y on tab {active}. \
+                 Call enable_a11y first, especially after Flutter route push. \
+                 Waiting for semantics that were never enabled will always timeout."
+            ));
+        }
+    }
+
     let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
     let t0 = std::time::Instant::now();
     loop {
@@ -1052,5 +1068,27 @@ mod tests {
     #[test]
     fn ax_value_to_string_returns_none_for_empty() {
         assert_eq!(ax_value_to_string(&None), None);
+    }
+
+    /// Verify that wait_for_ax_ready immediately returns Err when enable_a11y
+    /// has never been called for the active tab, instead of spinning for
+    /// the full timeout_ms (which would waste ~30 s per bad test call).
+    ///
+    /// This test exercises the guard path by ensuring the a11y-enabled set
+    /// does NOT contain the active tab index (0, since there's no real browser).
+    /// The function must return Err without sleeping.
+    #[test]
+    fn wait_for_ax_ready_errors_if_a11y_not_enabled() {
+        // Ensure tab 0 is NOT in the enabled set for this test.
+        // (Other tests in the suite do not touch a11y_tabs, but reset defensively.)
+        a11y_tabs().lock().unwrap_or_else(|e| e.into_inner()).remove(&0);
+
+        let result = wait_for_ax_ready(10, 5000);
+        assert!(result.is_err(), "expected Err when a11y not enabled, got {:?}", result);
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("enable_a11y"),
+            "error message should mention enable_a11y, got: {msg}"
+        );
     }
 }

--- a/src/test_runner/executor.rs
+++ b/src/test_runner/executor.rs
@@ -1653,6 +1653,13 @@ Flutter/CanvasKit interaction pattern (PREFERRED order using shadow DOM):
   4. shadow_type_flutter        — for text input fields (NOT shadow_type which uses InsertText)
   After route change: wait ≥ 1000ms → enable_a11y → shadow_dump → interact.
 
+**常見錯誤（會導致 30 秒 timeout）：**
+❌ shadow_click → wait 3000 → wait_for_ax_ready  （缺 enable_a11y → timeout）
+✓ shadow_click → wait 2000 → enable_a11y → wait_for_ax_ready  （正確）
+
+每次 Flutter route 切換後都要重新 enable_a11y。
+enable_a11y 必須在 wait_for_ax_ready 之前，否則語義樹永遠不會被初始化。
+
 Fallback to ax_find/ax_click if shadow_find returns "no shadow root".
 
 When you need EXACT text comparison (numbers, IDs), prefer ax_* over


### PR DESCRIPTION
## Summary

- **Fix 1 — `wait_for_ax_ready` guard** (`src/browser_ax.rs` L346): if `enable_a11y` was never called on the active tab, return `Err` immediately instead of spinning for the full `timeout_ms`. Eliminates silent 30-second walls when the LLM skips `enable_a11y`.
- **Fix 2 — `poll_tree_recovery` iterations** (`src/browser_ax.rs` L191): doubled the recovery window from `3×400ms` (1.2 s) to `6×600ms` (3.6 s). Covers slow Flutter builds where the Semantics tree takes up to 3 s to rebuild after a route push.
- **Fix 3 — Prompt anti-pattern** (`src/test_runner/executor.rs` prompt): added a ❌/✓ example block after the Flutter interaction pattern, explicitly showing that `wait_for_ax_ready` without a preceding `enable_a11y` will always timeout, and that `enable_a11y` must be re-called after every route change.

## Test plan

- [x] `cargo check --bin sirin` → 0 errors
- [x] `cargo test --bin sirin -- browser_ax wait_for_ax` → 10 passed (including new `wait_for_ax_ready_errors_if_a11y_not_enabled`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)