### PR TITLE
refactor(browser_exec): single shared dispatch (Closes #115)

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -134,17 +134,20 @@ fi
 echo
 echo "6. Action Registry Consistency (mcp_server vs builtins)"
 if [ -f "src/mcp_server.rs" ] && [ -f "src/adk/tool/builtins.rs" ]; then
-  # High-risk browser actions that should be in both
+  # High-risk browser actions that should be in both callers.
+  # Since Issue #115 the shared dispatch lives in src/browser_exec.rs; actions
+  # defined there count as "registered in builtins" because builtins delegates
+  # to browser_exec::dispatch().  We search both files.
   BROWSER_ACTIONS="goto screenshot screenshot_analyze click click_point type read eval wait exists attr scroll key console network url title close set_viewport enable_a11y ax_tree ax_find ax_value ax_click ax_focus ax_type ax_type_verified ax_snapshot ax_diff wait_for_ax_change wait_for_url wait_for_ax_ready wait_for_network_idle assert_ax_contains assert_url_matches shadow_find shadow_click shadow_dump flutter_type flutter_enter shadow_type_flutter go_back clear_state wait_new_tab wait_request list_sessions close_session dom_snapshot"
   MISSING_COUNT=0
   for action in $BROWSER_ACTIONS; do
-    if ! grep -q "\"$action\"" src/adk/tool/builtins.rs 2>/dev/null; then
-      warn "browser action '$action' missing from builtins.rs"
+    if ! grep -q "\"$action\"" src/adk/tool/builtins.rs src/browser_exec.rs 2>/dev/null; then
+      warn "browser action '$action' missing from builtins.rs and browser_exec.rs"
       MISSING_COUNT=$((MISSING_COUNT+1))
     fi
   done
   if [ "$MISSING_COUNT" -eq 0 ]; then
-    ok "all browser actions registered in builtins.rs"
+    ok "all browser actions registered in builtins.rs (or shared browser_exec.rs)"
   fi
 fi
 

--- a/src/adk/tool/builtins.rs
+++ b/src/adk/tool/builtins.rs
@@ -48,20 +48,6 @@ fn required_string_field(input: &Value, key: &str) -> Result<String, String> {
     optional_string_field(input, key).ok_or_else(|| format!("Missing '{key}' string"))
 }
 
-/// Issue #74: resolve `target` (CSS selector) OR `ref_id` (CiC-style stable id
-/// from `dom_snapshot`) into a single CSS selector usable by the legacy
-/// click/type/read/exists/hover paths.  `ref_id` wins when both are present.
-fn resolve_target(input: &Value, fallback_target: &str, action: &str) -> Result<String, String> {
-    if let Some(ref_id) = optional_string_field(input, "ref_id") {
-        return crate::browser::resolve_ref(&ref_id);
-    }
-    if !fallback_target.is_empty() {
-        return Ok(fallback_target.to_string());
-    }
-    Err(format!(
-        "'{action}' requires 'target' (CSS selector) or 'ref_id' (from dom_snapshot)"
-    ))
-}
 
 /// Register all discovered external MCP tools into a registry.
 fn register_mcp_tools(registry: ToolRegistry) -> ToolRegistry {
@@ -630,8 +616,9 @@ pub(super) fn build_full_registry() -> ToolRegistry {
             // Advanced:    viewport, pdf, file_upload, iframe_eval, drag, http_auth
             let action = optional_string_field(&input, "action")
                 .unwrap_or_else(|| "goto".to_string());
+            // target / extra_blocked are needed by the builtins-specific goto / screenshot_analyze handlers.
+            // All other parameter parsing is delegated to browser_exec::dispatch().
             let target = optional_string_field(&input, "target").unwrap_or_default();
-            let text = optional_string_field(&input, "text").unwrap_or_default();
 
             let action_label = action.clone(); // preserved for timeout diagnostics (action moves into closure)
             let test_run_id = ctx.metadata.get("test_run_id").cloned(); // Extract test_run_id before spawn_blocking
@@ -644,23 +631,30 @@ pub(super) fn build_full_registry() -> ToolRegistry {
                 .unwrap_or_default();
             let blocking_fut = tokio::task::spawn_blocking(move || -> Result<serde_json::Value, String> {
                 use crate::browser;
+
+                // ── Test-runner-specific actions (not in browser_exec) ────────
+                // These need caller-side context (test_run_id, extra_blocked) or
+                // return a special sentinel value for the outer async vision handler.
                 match action.as_str() {
-                    // ── Navigation ───────────────────────────────────
                     "goto" => {
-                        if target.is_empty() { return Err("'goto' requires a 'target' URL".into()); }
                         // Issue #81: pre-navigation URL blocklist (CiC-style guard).
-                        // Cheap path: zero CDP, zero LLM tokens, before browser sees URL.
+                        if target.is_empty() { return Err("'goto' requires a 'target' URL".into()); }
                         if let Some(matched) = crate::authz::check_blocked_url(&target, extra_blocked.iter()) {
                             return Err(format!(
                                 "BlockedByPolicy: URL {target:?} matched blocked pattern {matched:?}"
                             ));
                         }
-                        browser::navigate(&target)?;
-                        let png = browser::screenshot()?;
-                        crate::events::publish(crate::events::AgentEvent::BrowserScreenshotReady {
-                            png_bytes: png, url: target.clone(),
-                        });
-                        Ok(json!({ "status": "navigated", "url": target }))
+                        // Delegate the actual navigation to the shared dispatch.
+                        // We override `browser_headless` in `input` — but input is already the
+                        // full JSON from the caller which may already include it.
+                        let result = crate::browser_exec::dispatch("goto", &input)?;
+                        // Publish screenshot event after navigation (test-runner feedback loop).
+                        if let Ok(png) = browser::screenshot() {
+                            crate::events::publish(crate::events::AgentEvent::BrowserScreenshotReady {
+                                png_bytes: png, url: target.clone(),
+                            });
+                        }
+                        return Ok(result);
                     }
                     "screenshot" => {
                         let png = browser::screenshot()?;
@@ -668,620 +662,64 @@ pub(super) fn build_full_registry() -> ToolRegistry {
                         crate::events::publish(crate::events::AgentEvent::BrowserScreenshotReady {
                             png_bytes: png, url: url.clone(),
                         });
-                        Ok(json!({ "status": "screenshot captured", "url": url }))
+                        return Ok(json!({ "status": "screenshot captured", "url": url }));
                     }
-                    "title" => Ok(json!({ "title": browser::page_title()? })),
-                    "url"   => Ok(json!({ "url": browser::current_url()? })),
-                    "close" => { browser::close(); Ok(json!({ "status": "closed" })) }
-
-                    // ── DOM interaction ──────────────────────────────
-                    // Issue #74: each accepts EITHER `target` (selector) OR
-                    // `ref_id` (from dom_snapshot).  resolve_target() handles
-                    // both forms — ref_id wins when both are present.
-                    "click" => {
-                        let sel = resolve_target(&input, &target, "click")?;
-                        browser::click(&sel)?;
-                        Ok(json!({ "status": "clicked", "selector": sel }))
-                    }
-                    "type" => {
-                        let sel = resolve_target(&input, &target, "type")?;
-                        browser::type_text(&sel, &text)?;
-                        Ok(json!({ "status": "typed", "selector": sel, "length": text.len() }))
-                    }
-                    "read" => {
-                        let sel = resolve_target(&input, &target, "read")?;
-                        Ok(json!({ "selector": sel, "text": browser::get_text(&sel)? }))
-                    }
-                    "eval" => {
-                        if target.is_empty() { return Err("'eval' requires 'target' JS expression".into()); }
-                        Ok(json!({ "result": browser::evaluate_js(&target)? }))
-                    }
-                    "go_back" => {
-                        let wait_ms = input.get("wait").and_then(|v| v.as_u64()).unwrap_or(0);
-                        browser::go_back(wait_ms)?;
-                        let url = browser::current_url().unwrap_or_default();
-                        Ok(json!({ "status": "went_back", "url": url }))
-                    }
-                    "wait" => {
-                        if target.is_empty() { return Err("'wait' requires 'target' selector or ms number".into()); }
-                        // Plain number → millisecond sleep (e.g. {"action":"wait","target":"2000"}).
-                        if let Ok(ms) = target.trim().parse::<u64>() {
-                            std::thread::sleep(std::time::Duration::from_millis(ms));
-                            Ok(json!({ "status": "slept", "ms": ms }))
-                        } else {
-                            let ms = input.get("timeout").and_then(|v| v.as_u64()).unwrap_or(5000);
-                            browser::wait_for_ms(&target, ms)?;
-                            Ok(json!({ "status": "found", "selector": target }))
-                        }
-                    }
-                    "exists" => {
-                        // Issue #74: ref_id form returns false (rather than err)
-                        // when the ref is gone — matches the spirit of "does
-                        // this still exist?" instead of bubbling an error up.
-                        if let Some(ref_id) = optional_string_field(&input, "ref_id") {
-                            match browser::resolve_ref(&ref_id) {
-                                Ok(sel) => Ok(json!({
-                                    "ref_id": ref_id,
-                                    "selector": sel,
-                                    "exists": browser::element_exists(&sel)?
-                                })),
-                                Err(_) => Ok(json!({
-                                    "ref_id": ref_id,
-                                    "exists": false
-                                })),
-                            }
-                        } else if !target.is_empty() {
-                            Ok(json!({ "selector": target.clone(), "exists": browser::element_exists(&target)? }))
-                        } else {
-                            Err("'exists' requires 'target' selector or 'ref_id'".into())
-                        }
-                    }
-                    "count" => {
-                        if target.is_empty() { return Err("'count' requires 'target' selector".into()); }
-                        Ok(json!({ "selector": target, "count": browser::element_count(&target)? }))
-                    }
-                    "attr" => {
-                        if target.is_empty() { return Err("'attr' requires 'target' selector".into()); }
-                        if text.is_empty() { return Err("'attr' requires 'text' = attribute name".into()); }
-                        Ok(json!({ "selector": target, "attribute": &text, "value": browser::get_attribute(&target, &text)? }))
-                    }
-                    "value" => {
-                        if target.is_empty() { return Err("'value' requires 'target' selector".into()); }
-                        Ok(json!({ "selector": target, "value": browser::get_value(&target)? }))
-                    }
-
-                    // ── DOM snapshot (Issue #74) — CiC-style stable refs ─
-                    // `dom_snapshot` walks the visible DOM, assigns each
-                    // interactable element a short ref_id (e1, e2, …), and
-                    // returns {url, count, truncated, elements:[…]}.  Subsequent
-                    // click/type/read/exists/hover accept `ref_id` instead of
-                    // `target` to stay correct across re-renders.
+                    // DOM snapshot: test-runner stable ref-id system (builtins-only).
                     "dom_snapshot" => {
                         let max = input.get("max")
                             .and_then(Value::as_u64)
                             .map(|v| v as usize)
                             .unwrap_or(browser::DOM_SNAPSHOT_DEFAULT_MAX);
-                        let snap = browser::dom_snapshot(max)?;
-                        Ok(snap)
+                        return browser::dom_snapshot(max);
                     }
-
-                    // ── Keyboard / input ─────────────────────────────
-                    "key" => {
-                        if target.is_empty() { return Err("'key' requires 'target' key name".into()); }
-                        browser::press_key(&target)?;
-                        Ok(json!({ "status": "pressed", "key": target }))
-                    }
-                    "select" => {
-                        if target.is_empty() { return Err("'select' requires 'target' selector".into()); }
-                        if text.is_empty() { return Err("'select' requires 'text' = option value".into()); }
-                        browser::select_option(&target, &text)?;
-                        Ok(json!({ "status": "selected", "selector": target, "value": text }))
-                    }
-                    "scroll" => {
-                        let x = input.get("x").and_then(|v| v.as_f64()).unwrap_or(0.0);
-                        let y = input.get("y").and_then(|v| v.as_f64()).unwrap_or(300.0);
-                        browser::scroll_by(x, y)?;
-                        Ok(json!({ "status": "scrolled", "x": x, "y": y }))
-                    }
-                    "scroll_to" => {
-                        if target.is_empty() { return Err("'scroll_to' requires 'target' selector".into()); }
-                        browser::scroll_into_view(&target)?;
-                        Ok(json!({ "status": "scrolled_to", "selector": target }))
-                    }
-
-                    // ── Coordinate interaction ──────────────────────
-                    "click_point" => {
-                        let x = input.get("x").and_then(|v| v.as_f64()).ok_or("'click_point' requires 'x'")?;
-                        let y = input.get("y").and_then(|v| v.as_f64()).ok_or("'click_point' requires 'y'")?;
-                        // Issue #79: vision LLMs read coords off a screenshot whose
-                        // physical pixel size differs from the CSS viewport on HiDPI
-                        // monitors.  `coord_source="screenshot"` triggers
-                        // devicePixelRatio rescaling; anything else (or absent) is
-                        // treated as raw CSS pixels for backward compatibility.
-                        let source = input.get("coord_source").and_then(|v| v.as_str()).unwrap_or("css");
-                        match source {
-                            "screenshot" => browser::click_point_screenshot(x, y)?,
-                            _ => browser::click_point(x, y)?,
-                        }
-                        Ok(json!({ "status": "clicked", "x": x, "y": y, "coord_source": source }))
-                    }
-                    "hover" => {
-                        // Issue #74: accept ref_id from dom_snapshot.
-                        let sel = resolve_target(&input, &target, "hover")?;
-                        browser::hover(&sel)?;
-                        Ok(json!({ "status": "hovered", "selector": sel }))
-                    }
-                    "hover_point" => {
-                        let x = input.get("x").and_then(|v| v.as_f64()).ok_or("'hover_point' requires 'x'")?;
-                        let y = input.get("y").and_then(|v| v.as_f64()).ok_or("'hover_point' requires 'y'")?;
-                        let source = input.get("coord_source").and_then(|v| v.as_str()).unwrap_or("css");
-                        match source {
-                            "screenshot" => browser::hover_point_screenshot(x, y)?,
-                            _ => browser::hover_point(x, y)?,
-                        }
-                        Ok(json!({ "status": "hovered", "x": x, "y": y, "coord_source": source }))
-                    }
-
-                    // ── Tabs ─────────────────────────────────────────
-                    "new_tab" => {
-                        let idx = browser::new_tab()?;
-                        if !target.is_empty() { browser::navigate(&target)?; }
-                        Ok(json!({ "tab_index": idx }))
-                    }
-                    "switch_tab" => {
-                        let idx = input.get("index").and_then(|v| v.as_u64())
-                            .ok_or("'switch_tab' requires 'index'")? as usize;
-                        browser::switch_tab(idx)?;
-                        Ok(json!({ "status": "switched", "tab_index": idx }))
-                    }
-                    "close_tab" => {
-                        let idx = input.get("index").and_then(|v| v.as_u64())
-                            .ok_or("'close_tab' requires 'index'")? as usize;
-                        browser::close_tab(idx)?;
-                        Ok(json!({ "status": "tab_closed", "index": idx }))
-                    }
-                    "list_tabs" => {
-                        let tabs = browser::list_tabs()?;
-                        let active = browser::active_tab()?;
-                        let arr: Vec<serde_json::Value> = tabs.into_iter()
-                            .map(|(i, u)| json!({"index": i, "url": u, "active": i == active}))
-                            .collect();
-                        Ok(json!({ "tabs": arr }))
-                    }
-
-                    // ── Cookies ──────────────────────────────────────
-                    "cookies" => {
-                        let raw = browser::get_cookies()?;
-                        let val: serde_json::Value = serde_json::from_str(&raw).unwrap_or(json!([]));
-                        Ok(json!({ "cookies": val }))
-                    }
-                    "set_cookie" => {
-                        let name = input.get("name").and_then(|v| v.as_str()).unwrap_or_default();
-                        let value = input.get("value").and_then(|v| v.as_str()).unwrap_or_default();
-                        let domain = input.get("domain").and_then(|v| v.as_str()).unwrap_or_default();
-                        let path = input.get("path").and_then(|v| v.as_str()).unwrap_or("/");
-                        browser::set_cookie(name, value, domain, path)?;
-                        Ok(json!({ "status": "cookie_set", "name": name }))
-                    }
-                    "delete_cookie" => {
-                        if target.is_empty() { return Err("'delete_cookie' requires 'target' cookie name".into()); }
-                        browser::delete_cookie(&target)?;
-                        Ok(json!({ "status": "cookie_deleted", "name": target }))
-                    }
-
-                    // ── Storage ──────────────────────────────────────
-                    "localStorage_get" => {
-                        if target.is_empty() { return Err("requires 'target' key".into()); }
-                        Ok(json!({ "key": target, "value": browser::local_storage_get(&target)? }))
-                    }
-                    "localStorage_set" => {
-                        if target.is_empty() { return Err("requires 'target' key".into()); }
-                        browser::local_storage_set(&target, &text)?;
-                        Ok(json!({ "status": "set", "key": target }))
-                    }
-
-                    // ── Network / Console ────────────────────────────
-                    "network" => {
-                        let limit = input.get("limit").and_then(|v| v.as_u64()).unwrap_or(20) as usize;
-                        let raw = browser::captured_requests(limit)?;
-                        let val: serde_json::Value = serde_json::from_str(&raw).unwrap_or(json!([]));
-                        Ok(json!({ "requests": val }))
-                    }
-                    "console" => {
-                        let limit = input.get("limit").and_then(|v| v.as_u64()).unwrap_or(20) as usize;
-                        let raw = browser::console_messages(limit)?;
-                        let val: serde_json::Value = serde_json::from_str(&raw).unwrap_or(json!([]));
-                        Ok(json!({ "messages": val }))
-                    }
-                    "install_capture" => {
-                        browser::install_console_capture()?;
-                        browser::install_network_capture()?;
-                        Ok(json!({ "status": "console+network capture installed" }))
-                    }
-
-                    // ── Advanced ─────────────────────────────────────
-                    "viewport" => {
-                        let w = input.get("width").and_then(|v| v.as_u64()).unwrap_or(1280) as u32;
-                        let h = input.get("height").and_then(|v| v.as_u64()).unwrap_or(800) as u32;
-                        let scale = input.get("scale").and_then(|v| v.as_f64()).unwrap_or(1.0);
-                        let mobile = input.get("mobile").and_then(|v| v.as_bool()).unwrap_or(false);
-                        browser::set_viewport(w, h, scale, mobile)?;
-                        Ok(json!({ "status": "viewport_set", "width": w, "height": h }))
-                    }
-                    "pdf" => {
-                        let bytes = browser::pdf()?;
-                        Ok(json!({ "status": "pdf_exported", "bytes": bytes.len() }))
-                    }
-                    "drag" => {
-                        let fx = input.get("from_x").and_then(|v| v.as_f64()).ok_or("requires 'from_x'")?;
-                        let fy = input.get("from_y").and_then(|v| v.as_f64()).ok_or("requires 'from_y'")?;
-                        let tx = input.get("to_x").and_then(|v| v.as_f64()).ok_or("requires 'to_x'")?;
-                        let ty = input.get("to_y").and_then(|v| v.as_f64()).ok_or("requires 'to_y'")?;
-                        browser::drag(fx, fy, tx, ty)?;
-                        Ok(json!({ "status": "dragged" }))
-                    }
-                    "http_auth" => {
-                        let user = input.get("username").and_then(|v| v.as_str()).unwrap_or_default();
-                        let pass = input.get("password").and_then(|v| v.as_str()).unwrap_or_default();
-                        browser::set_http_auth(user, pass)?;
-                        Ok(json!({ "status": "auth_set" }))
-                    }
-
-                    // ── Accessibility tree (literal text, fast, Flutter-OK) ─
-                    "enable_a11y" => {
-                        crate::browser_ax::enable_flutter_semantics()?;
-                        // Poll until flt-semantics-host is non-empty (Flutter fills it async).
-                        // Max 15 × 200ms = 3 s; if still empty after that, return what we have.
-                        let mut shadow_ready = false;
-                        for _ in 0..15 {
-                            let count = browser::evaluate_js(
-                                "document.querySelector('flt-semantics-host')?.childElementCount||0"
-                            ).unwrap_or_default();
-                            if count.trim() != "0" {
-                                shadow_ready = true;
-                                break;
-                            }
-                            std::thread::sleep(std::time::Duration::from_millis(200));
-                        }
-                        let ax_count = {
-                            match crate::browser_ax::get_full_tree(false) {
-                                Ok(nodes) => nodes.len(),
-                                Err(_) => 0,
-                            }
-                        };
-                        Ok(json!({ "status": "semantics enabled", "ax_node_count": ax_count, "shadow_ready": shadow_ready }))
-                    }
-                    "wait_for_ax_ready" => {
-                        let min_nodes = input.get("min_nodes").and_then(Value::as_u64).unwrap_or(20) as usize;
-                        let timeout_ms = input.get("timeout_ms").or_else(|| input.get("timeout")).and_then(Value::as_u64).unwrap_or(10000);
-                        let (elapsed, count) = crate::browser_ax::wait_for_ax_ready(min_nodes, timeout_ms)?;
-                        Ok(json!({ "elapsed_ms": elapsed, "node_count": count }))
-                    }
-
-                    // wait_for_network_idle — block until the network has been quiet for idle_ms.
-                    // Essential for heavy Flutter pages (e.g. #/seller/product) that trigger
-                    // CDP silence timeouts if interacted with before all resources load.
-                    "wait_for_network_idle" => {
-                        let idle_ms = input.get("idle_ms").and_then(Value::as_u64).unwrap_or(500);
-                        let timeout_ms = input.get("timeout_ms").or_else(|| input.get("timeout")).and_then(Value::as_u64).unwrap_or(15000);
-                        let elapsed = crate::browser::wait_for_network_idle(idle_ms, timeout_ms)?;
-                        Ok(json!({ "elapsed_ms": elapsed, "status": "idle" }))
-                    }
-
-                    // wait_for_url — block until the current page URL matches target substring.
-                    "wait_for_url" => {
-                        let target_url = input.get("target").and_then(Value::as_str)
-                            .ok_or("'wait_for_url' requires 'target' = URL substring")?
-                            .to_string();
-                        let timeout_ms = input.get("timeout_ms").or_else(|| input.get("timeout")).and_then(Value::as_u64).unwrap_or(10000);
-                        let elapsed = crate::browser::wait_for_url(&target_url, timeout_ms)?;
-                        Ok(json!({ "elapsed_ms": elapsed, "url": target_url, "status": "matched" }))
-                    }
-
-                    // Assertions (mirror mcp_server.rs — wired 2026-04-28)
-                    "assert_ax_contains" => {
-                        if target.is_empty() {
-                            return Err("'assert_ax_contains' requires 'target' = text to find".into());
-                        }
-                        let tree = crate::browser_ax::get_full_tree(false)?;
-                        let needle = target.to_lowercase();
-                        let found = tree.iter().any(|n| {
-                            n.name.as_deref().unwrap_or("").to_lowercase().contains(&needle)
-                                || n.value.as_deref().unwrap_or("").to_lowercase().contains(&needle)
-                        });
-                        let preview: Vec<String> = tree.iter().take(20)
-                            .filter_map(|n| n.name.clone().or_else(|| n.value.clone()))
-                            .collect();
-                        Ok(json!({ "passed": found, "target": target, "actual_ax_tree_preview": preview.join(" | ") }))
-                    }
-                    "assert_url_matches" => {
-                        if target.is_empty() {
-                            return Err("'assert_url_matches' requires 'target' (URL substring or /regex/)".into());
-                        }
-                        let url = browser::current_url().unwrap_or_default();
-                        let is_regex = target.starts_with('/') && target.ends_with('/') && target.len() > 2;
-                        let passed = if is_regex {
-                            let pattern = &target[1..target.len() - 1];
-                            regex::Regex::new(pattern).map(|re| re.is_match(&url)).unwrap_or(false)
-                        } else {
-                            url.contains(&target)
-                        };
-                        Ok(json!({ "passed": passed, "target": target, "actual_url": url }))
-                    }
-
-                    // Multi-session management (mirror mcp_server.rs — wired 2026-04-28)
-                    "list_sessions" => {
-                        let sessions = browser::list_sessions().unwrap_or_default();
-                        let items: Vec<Value> = sessions.into_iter().map(|(id, idx, url)| {
-                            json!({ "session_id": id, "tab_index": idx, "url": url })
-                        }).collect();
-                        Ok(json!({ "count": items.len(), "sessions": items }))
-                    }
-                    "close_session" => {
-                        if target.is_empty() {
-                            return Err("'close_session' requires 'target' = session_id".into());
-                        }
-                        browser::close_session(&target)?;
-                        Ok(json!({ "status": "closed", "session_id": target }))
-                    }
-
-                    // ── Flutter Shadow DOM (bypasses CDP AX protocol) ─────────
-                    "shadow_find" => {
-                        let role = optional_string_field(&input, "role");
-                        let name = optional_string_field(&input, "name_regex")
-                            .or_else(|| optional_string_field(&input, "name"));
-                        let (x, y, label) = browser::shadow_find(role.as_deref(), name.as_deref())?;
-                        Ok(json!({ "found": true, "x": x, "y": y, "label": label }))
-                    }
-                    "shadow_click" => {
-                        let role = optional_string_field(&input, "role");
-                        let name = optional_string_field(&input, "name_regex")
-                            .or_else(|| optional_string_field(&input, "name"));
-                        let label = browser::shadow_click(role.as_deref(), name.as_deref())?;
-                        Ok(json!({ "status": "clicked", "label": label }))
-                    }
-                    "shadow_type" => {
-                        let role = optional_string_field(&input, "role");
-                        let name = optional_string_field(&input, "name_regex")
-                            .or_else(|| optional_string_field(&input, "name"));
-                        let text_val = input.get("text").and_then(Value::as_str)
-                            .ok_or("'shadow_type' requires 'text'")?;
-                        browser::shadow_type(role.as_deref(), name.as_deref(), text_val)?;
-                        Ok(json!({ "status": "typed", "text": text_val }))
-                    }
-                    // Flutter-native typing: shadow_click → wait 300ms → flutter_type
-                    // Use this instead of shadow_type for Flutter textboxes (which need
-                    // keydown events, not Input.InsertText).
-                    "flutter_type" => {
-                        // Accept both string "50" and number 50
-                        let text_owned = input.get("text")
-                            .map(|v| if let Some(s) = v.as_str() { s.to_string() } else { v.to_string().trim_matches('"').to_string() })
-                            .ok_or("'flutter_type' requires 'text'")?;
-                        browser::flutter_type(&text_owned)?;
-                        Ok(json!({ "status": "typed", "text": text_owned }))
-                    }
-                    "flutter_enter" => {
-                        // Send Enter key to the active flt-text-editing input — submits chat/form
-                        let result = browser::flutter_enter()?;
-                        Ok(json!({ "status": "ok", "result": result }))
-                    }
-                    "shadow_type_flutter" => {
-                        // All-in-one: find + click + wait 350ms + flutter_type
-                        let role = optional_string_field(&input, "role");
-                        let name = optional_string_field(&input, "name_regex")
-                            .or_else(|| optional_string_field(&input, "name"));
-                        let text_owned = input.get("text")
-                            .map(|v| if let Some(s) = v.as_str() { s.to_string() } else { v.to_string().trim_matches('"').to_string() })
-                            .ok_or("'shadow_type_flutter' requires 'text'")?;
-                        let label = browser::shadow_click(role.as_deref(), name.as_deref())?;
-                        std::thread::sleep(std::time::Duration::from_millis(350));
-                        browser::flutter_type(&text_owned)?;
-                        Ok(json!({ "status": "typed", "label": label, "text": text_owned }))
-                    }
-                    "shadow_dump" => {
-                        let items = browser::shadow_dump()?;
-                        Ok(json!({ "count": items.len(), "elements": items }))
-                    }
-
+                    // ax_tree: P1.2 optimisation — diff mode when test_run_id present.
                     "ax_tree" => {
                         let include_ignored = input.get("include_ignored").and_then(Value::as_bool).unwrap_or(false);
                         let nodes = crate::browser_ax::get_full_tree(include_ignored)?;
-                        
-                        // P1.2 optimization: Use A11y tree auto-diffing to reduce tokens
+
                         if let Some(rid) = &test_run_id {
-                            // Serialize nodes to tree format for diffing
-                            let tree_value: Value = serde_json::to_value(&nodes)
-                                .unwrap_or(json!({}));
-                            
-                            // Determine if this is the first call
+                            let tree_value: Value = serde_json::to_value(&nodes).unwrap_or(json!({}));
                             let mut is_first = false;
                             crate::test_runner::runs::mutate_ax_diff_context(rid, |diff_ctx| {
                                 is_first = diff_ctx.set_baseline_if_first(tree_value.clone());
                             });
-                            
-                            // If not first call, compute and return diff
                             if !is_first {
                                 if let Some(diff_ctx) = crate::test_runner::runs::get_ax_diff_context(rid) {
                                     let diff_result = diff_ctx.compute_diff(&tree_value);
                                     return Ok(json!({
-                                        "count": nodes.len(),
-                                        "nodes": nodes,
-                                        "diff_mode": true,
-                                        "diff_summary": diff_result,
+                                        "count": nodes.len(), "nodes": nodes,
+                                        "diff_mode": true, "diff_summary": diff_result,
                                     }));
                                 }
                             }
-                            
-                            // First call or no diff context: return full tree
-                            Ok(json!({
-                                "count": nodes.len(),
-                                "nodes": nodes,
+                            return Ok(json!({
+                                "count": nodes.len(), "nodes": nodes,
                                 "first_ax_tree_call": is_first,
-                            }))
-                        } else {
-                            // No test_run_id in context: return full tree
-                            Ok(json!({ "count": nodes.len(), "nodes": nodes }))
+                            }));
                         }
+                        return Ok(json!({ "count": nodes.len(), "nodes": nodes }));
                     }
-                    "ax_find" => {
-                        let role = optional_string_field(&input, "role");
-                        let name = optional_string_field(&input, "name");
-                        if role.is_none() && name.is_none() {
-                            return Err("'ax_find' requires 'role' and/or 'name'".into());
-                        }
-                        let name_regex = optional_string_field(&input, "name_regex");
-                        let not_name_matches: Vec<String> = input
-                            .get("not_name_matches")
-                            .and_then(Value::as_array)
-                            .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
-                            .unwrap_or_default();
-                        let limit = input.get("limit").and_then(Value::as_u64).unwrap_or(1) as usize;
-
-                        if limit <= 1 {
-                            match crate::browser_ax::find_by_role_and_name(
-                                role.as_deref(), name.as_deref(),
-                                name_regex.as_deref(), &not_name_matches,
-                            )? {
-                                Some(n) => Ok(json!({ "found": true, "node": n })),
-                                None    => Ok(json!({ "found": false, "node": null })),
-                            }
-                        } else {
-                            let nodes = crate::browser_ax::find_all_by_role_and_name(
-                                role.as_deref(), name.as_deref(),
-                                name_regex.as_deref(), &not_name_matches, limit,
-                            )?;
-                            Ok(json!({
-                                "found": !nodes.is_empty(),
-                                "count": nodes.len(),
-                                "nodes": nodes,
-                            }))
-                        }
-                    }
-                    "ax_snapshot" => {
-                        let snap_id_arg = optional_string_field(&input, "id");
-                        let id = crate::browser_ax::ax_snapshot(snap_id_arg.as_deref())?;
-                        Ok(json!({ "snapshot_id": id }))
-                    }
-                    "ax_diff" => {
-                        let before = input.get("before_id").and_then(Value::as_str)
-                            .ok_or("'ax_diff' requires 'before_id'")?;
-                        let after = input.get("after_id").and_then(Value::as_str)
-                            .ok_or("'ax_diff' requires 'after_id'")?;
-                        let diff = crate::browser_ax::ax_diff(before, after)?;
-                        Ok(json!({
-                            "added_count":   diff.added.len(),
-                            "removed_count": diff.removed.len(),
-                            "changed_count": diff.changed.len(),
-                            "added":   diff.added.iter().map(|n| json!({"node_id": n.node_id, "role": n.role, "name": n.name})).collect::<Vec<_>>(),
-                            "removed": diff.removed.iter().map(|n| json!({"node_id": n.node_id, "role": n.role, "name": n.name})).collect::<Vec<_>>(),
-                            "changed": diff.changed,
-                        }))
-                    }
-                    "wait_for_ax_change" => {
-                        let baseline_id = input.get("baseline_id").and_then(Value::as_str)
-                            .ok_or("'wait_for_ax_change' requires 'baseline_id'")?;
-                        let timeout_ms = input.get("timeout").and_then(Value::as_u64).unwrap_or(5000);
-                        let (new_id, diff) = crate::browser_ax::wait_for_ax_change(baseline_id, timeout_ms)?;
-                        Ok(json!({
-                            "new_snapshot_id": new_id,
-                            "added_count":   diff.added.len(),
-                            "removed_count": diff.removed.len(),
-                            "changed_count": diff.changed.len(),
-                        }))
-                    }
-                    "ax_value" => {
-                        let backend_id = input.get("backend_id").and_then(Value::as_u64)
-                            .ok_or("'ax_value' requires 'backend_id' (number)")?;
-                        let text = crate::browser_ax::read_node_text(backend_id as u32)?;
-                        Ok(json!({ "backend_id": backend_id, "text": text }))
-                    }
-                    "ax_click" => {
-                        let backend_id = input.get("backend_id").and_then(Value::as_u64)
-                            .ok_or("'ax_click' requires 'backend_id' (number)")?;
-                        crate::browser_ax::click_backend(backend_id as u32)?;
-                        Ok(json!({ "status": "clicked", "backend_id": backend_id }))
-                    }
-                    "ax_focus" => {
-                        let backend_id = input.get("backend_id").and_then(Value::as_u64)
-                            .ok_or("'ax_focus' requires 'backend_id' (number)")?;
-                        crate::browser_ax::focus_backend(backend_id as u32)?;
-                        Ok(json!({ "status": "focused", "backend_id": backend_id }))
-                    }
-                    "ax_type" => {
-                        let backend_id = input.get("backend_id").and_then(Value::as_u64)
-                            .ok_or("'ax_type' requires 'backend_id' (number)")?;
-                        crate::browser_ax::type_into_backend(backend_id as u32, &text)?;
-                        Ok(json!({ "status": "typed", "backend_id": backend_id, "length": text.len() }))
-                    }
-                    "ax_type_verified" => {
-                        let backend_id = input.get("backend_id").and_then(Value::as_u64)
-                            .ok_or("'ax_type_verified' requires 'backend_id' (number)")?;
-                        let r = crate::browser_ax::type_into_backend_verified(backend_id as u32, &text)?;
-                        Ok(json!(r))
-                    }
-
-                    // ── Test isolation ───────────────────────────
-                    "clear_state" => {
-                        browser::clear_browser_state()?;
-                        Ok(json!({ "status": "cleared" }))
-                    }
-
-                    "set_viewport" => {
-                        let w = input.get("width").and_then(Value::as_u64).unwrap_or(1440) as u32;
-                        let h = input.get("height").and_then(Value::as_u64).unwrap_or(1600) as u32;
-                        let scale = input.get("scale").and_then(Value::as_f64).unwrap_or(1.0);
-                        let mobile = input.get("mobile").and_then(Value::as_bool).unwrap_or(false);
-                        browser::set_viewport(w, h, scale, mobile)?;
-                        Ok(json!({ "status": "viewport_set", "width": w, "height": h }))
-                    }
-
-                    // ── Multi-tab / popup ────────────────────────
-                    "wait_new_tab" => {
-                        let timeout = input.get("timeout").and_then(Value::as_u64).unwrap_or(10000);
-                        // baseline=None → fn measures from same source as its loop
-                        let idx = browser::wait_for_new_tab(None, timeout)?;
-                        Ok(json!({ "status": "new tab opened", "active_tab": idx }))
-                    }
-
-                    // ── Network ──────────────────────────────────
-                    "wait_request" => {
-                        if target.is_empty() { return Err("'wait_request' requires 'target' = URL substring".into()); }
-                        let timeout = input.get("timeout").and_then(Value::as_u64).unwrap_or(10000);
-                        let raw = browser::wait_for_request(&target, timeout)?;
-                        let val: Value = serde_json::from_str(&raw).unwrap_or(json!({}));
-                        Ok(json!({ "request": val }))
-                    }
-
-                    // ── Vision: screenshot + LLM analysis ────────
+                    // screenshot_analyze: capture PNG once here; outer async handler
+                    // does the LLM call with cache + SoM support.
                     "screenshot_analyze" => {
-                        // Take screenshot, send to vision LLM with prompt, return analysis
                         if target.is_empty() {
                             return Err("'screenshot_analyze' requires 'target' = analysis prompt".into());
                         }
-                        // Capture screenshot ONCE on this blocking thread.
-                        // Pre-fix: this branch returned only `png_len` and the
-                        // outer async block then captured the screenshot
-                        // THREE more times (cache lookup, LLM call, cache
-                        // store) for a total of 4 captures per analyze call.
-                        // Each `browser::screenshot()` is a synchronous CDP
-                        // round-trip (~0.5–1 s), so a vision call burned
-                        // 1.5–3 s of pure overhead before the LLM saw a byte.
-                        // Now: capture once, base64-encode here, pass the b64
-                        // through the JSON channel so downstream uses it for
-                        // hash + LLM + cache store without re-capturing.
                         let png = browser::screenshot()?;
                         let png_len = png.len();
                         let b64 = crate::llm::base64_encode_bytes(&png);
-                        Ok(json!({
+                        return Ok(json!({
                             "__vision": true,
-                            "prompt": target,
-                            "png_len": png_len,
-                            "png_b64": b64,
-                        }))
+                            "prompt":   target,
+                            "png_len":  png_len,
+                            "png_b64":  b64,
+                        }));
                     }
-
-                    other => Err(format!("Unknown web_navigate action: {other}")),
+                    _ => {}
                 }
+
+                // ── All other actions: shared dispatch ────────────────────────
+                crate::browser_exec::dispatch(action.as_str(), &input)
             });
             // ── CDP call timeout ──────────────────────────────────────────────
             // If Chrome crashes mid-call the spawned blocking thread can block

--- a/src/browser_exec.rs
+++ b/src/browser_exec.rs
@@ -1,0 +1,648 @@
+//! Single source of truth for all browser action dispatch.
+//!
+//! Called from both `mcp_server.rs` (the external MCP/RPC API) and the
+//! `web_navigate` builtin in `adk/tool/builtins.rs` (the test-runner ReAct
+//! loop).  Any action added here is automatically available in both callers
+//! with zero duplication — which was the root cause of the drift that
+//! prompted Issue #115.
+//!
+//! # Design notes
+//!
+//! * All parameters are read from `input: &serde_json::Value`.  Callers may
+//!   add extra keys (e.g. `test_run_id`, `blocked_url_patterns`) that this
+//!   module simply ignores — so caller-specific behaviour stays in the caller.
+//!
+//! * Actions that are **caller-specific** are NOT here:
+//!   - `screenshot_analyze` — builtins has vision cache + SoM; mcp_server has
+//!     a simpler sync path.  Both callers handle it before reaching this fn.
+//!   - `ocr_find_text` — async OCR helper; handled in caller.
+//!   - `dom_snapshot` — used only by builtins (test runner ref-id system).
+//!   - `ext_status / ext_url / ext_tabs` — MCP-only extension probes.
+//!
+//! * `session_id` / `headless` pre-processing (goto + session_switch) happens
+//!   in the caller before calling this fn, so this fn assumes the session is
+//!   already correct.
+
+use serde_json::{json, Value};
+
+// ── Inline helpers ────────────────────────────────────────────────────────────
+
+fn str_field<'a>(input: &'a Value, key: &str) -> &'a str {
+    input.get(key).and_then(Value::as_str).unwrap_or("")
+}
+
+fn opt_str(input: &Value, key: &str) -> Option<String> {
+    input.get(key).and_then(Value::as_str).map(String::from)
+}
+
+fn opt_str2<'a>(input: &'a Value, k1: &str, k2: &str) -> Option<&'a str> {
+    input.get(k1).or_else(|| input.get(k2)).and_then(Value::as_str)
+}
+
+fn u64_field(input: &Value, key: &str, default: u64) -> u64 {
+    input.get(key).and_then(Value::as_u64).unwrap_or(default)
+}
+
+fn f64_field(input: &Value, key: &str, default: f64) -> f64 {
+    input.get(key).and_then(Value::as_f64).unwrap_or(default)
+}
+
+fn bool_field(input: &Value, key: &str, default: bool) -> bool {
+    input.get(key).and_then(Value::as_bool).unwrap_or(default)
+}
+
+/// Try to resolve `ref_id` first (dom_snapshot stable ref), then fall back
+/// to plain `target`.  Mirrors `resolve_target` in builtins.rs.
+fn resolve_selector(input: &Value, target: &str, action: &str) -> Result<String, String> {
+    if let Some(ref_id) = opt_str(input, "ref_id") {
+        return crate::browser::resolve_ref(&ref_id)
+            .map_err(|e| format!("ref_id lookup failed for '{action}': {e}"));
+    }
+    if target.is_empty() {
+        return Err(format!("'{action}' requires 'target' selector or 'ref_id'"));
+    }
+    Ok(target.to_string())
+}
+
+// ── Public dispatch entry point ───────────────────────────────────────────────
+
+/// Dispatch a browser action.
+///
+/// `input` is the full JSON object from the caller.  All parameters are read
+/// from it by key name.  Unknown keys are silently ignored.
+///
+/// Returns `Err(String)` for both validation errors and browser errors.
+///
+/// # Caller responsibility
+///
+/// Before calling this function the caller MUST:
+/// 1. Handle `screenshot_analyze`, `ocr_find_text`, `dom_snapshot`,
+///    `ext_status/url/tabs` themselves (these are not in this dispatch).
+/// 2. For `goto` with `session_id`: call `browser::ensure_open(headless)` then
+///    `browser::session_switch(sid)` before dispatching.
+pub(crate) fn dispatch(action: &str, input: &Value) -> Result<Value, String> {
+    use crate::browser;
+
+    let target  = str_field(input, "target");
+    let text    = str_field(input, "text");
+
+    match action {
+        // ── Navigation ───────────────────────────────────────────────────
+        "goto" => {
+            if target.is_empty() { return Err("'goto' requires 'target' URL".into()); }
+            // authz check is caller-responsibility (builtins does it pre-dispatch)
+            let headless = input.get("browser_headless")
+                .and_then(Value::as_bool)
+                .unwrap_or_else(browser::default_headless);
+            browser::ensure_open(headless)?;
+            browser::navigate(target)?;
+            Ok(json!({ "status": "navigated", "url": target }))
+        }
+        "screenshot" => {
+            let png = browser::screenshot()?;
+            let b64 = crate::llm::base64_encode_bytes(&png);
+            let url = browser::current_url().unwrap_or_default();
+            Ok(json!({
+                "mime":         "image/png",
+                "bytes_base64": b64,
+                "size_bytes":   png.len(),
+                "url":          url,
+            }))
+        }
+        "title" => Ok(json!({ "title": browser::page_title()? })),
+        "url"   => Ok(json!({ "url":   browser::current_url()? })),
+        "close" => { browser::close(); Ok(json!({ "status": "closed" })) }
+
+        // ── DOM interaction ──────────────────────────────────────────────
+        "click" => {
+            let sel = resolve_selector(input, target, "click")?;
+            browser::click(&sel)?;
+            Ok(json!({ "status": "clicked", "selector": sel }))
+        }
+        "type" => {
+            let sel = resolve_selector(input, target, "type")?;
+            browser::type_text(&sel, text)?;
+            Ok(json!({ "status": "typed", "selector": sel, "length": text.len() }))
+        }
+        "read" => {
+            let sel = resolve_selector(input, target, "read")?;
+            Ok(json!({ "selector": sel, "text": browser::get_text(&sel)? }))
+        }
+        "eval" => {
+            if target.is_empty() { return Err("'eval' requires 'target' JS expression".into()); }
+            Ok(json!({ "result": browser::evaluate_js(target)? }))
+        }
+        "go_back" => {
+            let wait_ms = u64_field(input, "wait", 0);
+            browser::go_back(wait_ms)?;
+            let url = browser::current_url().unwrap_or_default();
+            Ok(json!({ "status": "went_back", "url": url }))
+        }
+        "wait" => {
+            if target.is_empty() { return Err("'wait' requires 'target' selector or ms number".into()); }
+            // Plain number → millisecond sleep (e.g. {"action":"wait","target":"2000"}).
+            if let Ok(ms) = target.trim().parse::<u64>() {
+                std::thread::sleep(std::time::Duration::from_millis(ms));
+                Ok(json!({ "status": "slept", "ms": ms }))
+            } else {
+                let ms = input.get("timeout").and_then(Value::as_u64).unwrap_or(5000);
+                browser::wait_for_ms(target, ms)?;
+                Ok(json!({ "status": "found", "selector": target }))
+            }
+        }
+        "exists" => {
+            if let Some(ref_id) = opt_str(input, "ref_id") {
+                match browser::resolve_ref(&ref_id) {
+                    Ok(sel) => Ok(json!({
+                        "ref_id": ref_id, "selector": sel,
+                        "exists": browser::element_exists(&sel)?
+                    })),
+                    Err(_) => Ok(json!({ "ref_id": ref_id, "exists": false })),
+                }
+            } else if !target.is_empty() {
+                Ok(json!({ "selector": target, "exists": browser::element_exists(target)? }))
+            } else {
+                Err("'exists' requires 'target' selector or 'ref_id'".into())
+            }
+        }
+        "count" => {
+            if target.is_empty() { return Err("'count' requires 'target' selector".into()); }
+            Ok(json!({ "selector": target, "count": browser::element_count(target)? }))
+        }
+        "attr" => {
+            if target.is_empty() { return Err("'attr' requires 'target' selector".into()); }
+            if text.is_empty()   { return Err("'attr' requires 'text' = attribute name".into()); }
+            Ok(json!({ "selector": target, "attribute": text,
+                        "value": browser::get_attribute(target, text)? }))
+        }
+        "value" => {
+            if target.is_empty() { return Err("'value' requires 'target' selector".into()); }
+            Ok(json!({ "selector": target, "value": browser::get_value(target)? }))
+        }
+
+        // ── Keyboard / input ─────────────────────────────────────────────
+        "key" => {
+            if target.is_empty() { return Err("'key' requires 'target' key name".into()); }
+            browser::press_key(target)?;
+            Ok(json!({ "status": "pressed", "key": target }))
+        }
+        "select" => {
+            if target.is_empty() { return Err("'select' requires 'target' selector".into()); }
+            if text.is_empty()   { return Err("'select' requires 'text' = option value".into()); }
+            browser::select_option(target, text)?;
+            Ok(json!({ "status": "selected", "selector": target, "value": text }))
+        }
+        "scroll" => {
+            let x = f64_field(input, "x", 0.0);
+            let y = f64_field(input, "y", 300.0);
+            browser::scroll_by(x, y)?;
+            Ok(json!({ "status": "scrolled", "x": x, "y": y }))
+        }
+        "scroll_to" => {
+            if target.is_empty() { return Err("'scroll_to' requires 'target' selector".into()); }
+            browser::scroll_into_view(target)?;
+            Ok(json!({ "status": "scrolled_to", "selector": target }))
+        }
+
+        // ── Coordinate interaction ───────────────────────────────────────
+        "click_point" => {
+            let x = input.get("x").and_then(Value::as_f64)
+                .ok_or("'click_point' requires 'x' (number)")?;
+            let y = input.get("y").and_then(Value::as_f64)
+                .ok_or("'click_point' requires 'y' (number)")?;
+            // Issue #79: HiDPI screenshot coords need devicePixelRatio rescaling.
+            let source = input.get("coord_source").and_then(Value::as_str).unwrap_or("css");
+            match source {
+                "screenshot" => browser::click_point_screenshot(x, y)?,
+                _            => browser::click_point(x, y)?,
+            }
+            Ok(json!({ "status": "clicked", "x": x, "y": y, "coord_source": source }))
+        }
+        "hover" => {
+            let sel = resolve_selector(input, target, "hover")?;
+            browser::hover(&sel)?;
+            Ok(json!({ "status": "hovered", "selector": sel }))
+        }
+        "hover_point" => {
+            let x = input.get("x").and_then(Value::as_f64)
+                .ok_or("'hover_point' requires 'x'")?;
+            let y = input.get("y").and_then(Value::as_f64)
+                .ok_or("'hover_point' requires 'y'")?;
+            let source = input.get("coord_source").and_then(Value::as_str).unwrap_or("css");
+            match source {
+                "screenshot" => browser::hover_point_screenshot(x, y)?,
+                _            => browser::hover_point(x, y)?,
+            }
+            Ok(json!({ "status": "hovered", "x": x, "y": y, "coord_source": source }))
+        }
+
+        // ── Tabs ─────────────────────────────────────────────────────────
+        "new_tab" => {
+            let idx = browser::new_tab()?;
+            if !target.is_empty() { browser::navigate(target)?; }
+            Ok(json!({ "tab_index": idx }))
+        }
+        "switch_tab" => {
+            let idx = input.get("index").and_then(Value::as_u64)
+                .ok_or("'switch_tab' requires 'index'")? as usize;
+            browser::switch_tab(idx)?;
+            Ok(json!({ "status": "switched", "tab_index": idx }))
+        }
+        "close_tab" => {
+            let idx = input.get("index").and_then(Value::as_u64)
+                .ok_or("'close_tab' requires 'index'")? as usize;
+            browser::close_tab(idx)?;
+            Ok(json!({ "status": "tab_closed", "index": idx }))
+        }
+        "list_tabs" => {
+            let tabs = browser::list_tabs()?;
+            let active = browser::active_tab()?;
+            let arr: Vec<Value> = tabs.into_iter()
+                .map(|(i, u)| json!({"index": i, "url": u, "active": i == active}))
+                .collect();
+            Ok(json!({ "tabs": arr }))
+        }
+
+        // ── Cookies ──────────────────────────────────────────────────────
+        "cookies" => {
+            let raw = browser::get_cookies()?;
+            let val: Value = serde_json::from_str(&raw).unwrap_or(json!([]));
+            Ok(json!({ "cookies": val }))
+        }
+        "set_cookie" => {
+            let name   = str_field(input, "name");
+            let value  = str_field(input, "value");
+            let domain = str_field(input, "domain");
+            let path   = input.get("path").and_then(Value::as_str).unwrap_or("/");
+            browser::set_cookie(name, value, domain, path)?;
+            Ok(json!({ "status": "cookie_set", "name": name }))
+        }
+        "delete_cookie" => {
+            if target.is_empty() { return Err("'delete_cookie' requires 'target' cookie name".into()); }
+            browser::delete_cookie(target)?;
+            Ok(json!({ "status": "cookie_deleted", "name": target }))
+        }
+
+        // ── Storage ──────────────────────────────────────────────────────
+        "localStorage_get" => {
+            if target.is_empty() { return Err("requires 'target' key".into()); }
+            Ok(json!({ "key": target, "value": browser::local_storage_get(target)? }))
+        }
+        "localStorage_set" => {
+            if target.is_empty() { return Err("requires 'target' key".into()); }
+            browser::local_storage_set(target, text)?;
+            Ok(json!({ "status": "set", "key": target }))
+        }
+
+        // ── Network / Console ────────────────────────────────────────────
+        "network" => {
+            let limit = u64_field(input, "limit", 20) as usize;
+            let raw = browser::captured_requests(limit)?;
+            let val: Value = serde_json::from_str(&raw).unwrap_or(json!([]));
+            Ok(json!({ "requests": val }))
+        }
+        "console" => {
+            let limit = u64_field(input, "limit", 20) as usize;
+            let raw = browser::console_messages(limit)?;
+            let val: Value = serde_json::from_str(&raw).unwrap_or(json!([]));
+            Ok(json!({ "messages": val }))
+        }
+        "install_capture" => {
+            browser::install_console_capture()?;
+            browser::install_network_capture()?;
+            Ok(json!({ "status": "console+network capture installed" }))
+        }
+
+        // ── Advanced ─────────────────────────────────────────────────────
+        "viewport" | "set_viewport" => {
+            let w     = u64_field(input, "width",  1280) as u32;
+            let h     = u64_field(input, "height",  800) as u32;
+            let scale = f64_field(input, "scale",   1.0);
+            let mobile = bool_field(input, "mobile", false);
+            browser::set_viewport(w, h, scale, mobile)?;
+            Ok(json!({ "status": "viewport_set", "width": w, "height": h }))
+        }
+        "pdf" => {
+            let bytes = browser::pdf()?;
+            Ok(json!({ "status": "pdf_exported", "bytes": bytes.len() }))
+        }
+        "drag" => {
+            let fx = input.get("from_x").and_then(Value::as_f64).ok_or("requires 'from_x'")?;
+            let fy = input.get("from_y").and_then(Value::as_f64).ok_or("requires 'from_y'")?;
+            let tx = input.get("to_x").and_then(Value::as_f64).ok_or("requires 'to_x'")?;
+            let ty = input.get("to_y").and_then(Value::as_f64).ok_or("requires 'to_y'")?;
+            browser::drag(fx, fy, tx, ty)?;
+            Ok(json!({ "status": "dragged" }))
+        }
+        "http_auth" => {
+            let user = str_field(input, "username");
+            let pass = str_field(input, "password");
+            browser::set_http_auth(user, pass)?;
+            Ok(json!({ "status": "auth_set" }))
+        }
+
+        // ── Accessibility tree ───────────────────────────────────────────
+        "enable_a11y" => {
+            // Always call enable_flutter_semantics() to trigger the placeholder
+            // click that builds flt-semantics-host DOM elements.
+            // Safety net: detect about:blank URL reset and restore.
+            let saved_url = crate::browser::current_url().ok();
+            let _ = crate::browser_ax::enable_flutter_semantics();
+            // Poll until flt-semantics-host is non-empty (Flutter fills it async).
+            let mut shadow_ready = false;
+            for _ in 0..15 {
+                let count = browser::evaluate_js(
+                    "document.querySelector('flt-semantics-host')?.childElementCount||0"
+                ).unwrap_or_default();
+                if count.trim() != "0" {
+                    shadow_ready = true;
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(200));
+            }
+            if let Some(ref url) = saved_url {
+                let cur = crate::browser::current_url().unwrap_or_default();
+                if cur.contains("about:blank") && !url.contains("about:blank") && !url.is_empty() {
+                    tracing::warn!(
+                        "[browser_exec] enable_a11y: URL reset detected (about:blank) — restoring {url:?}"
+                    );
+                    let _ = crate::browser::navigate(url);
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                }
+            }
+            let tree = crate::browser_ax::get_full_tree(false).unwrap_or_default();
+            Ok(json!({ "status": "semantics enabled", "ax_node_count": tree.len(), "shadow_ready": shadow_ready }))
+        }
+        "ax_tree" => {
+            let include_ignored = bool_field(input, "include_ignored", false);
+            let nodes = crate::browser_ax::get_full_tree(include_ignored)?;
+            Ok(json!({ "count": nodes.len(), "nodes": nodes }))
+        }
+        "ax_find" => {
+            let role = opt_str(input, "role");
+            let name = opt_str(input, "name");
+            if role.is_none() && name.is_none() {
+                return Err("'ax_find' requires 'role' and/or 'name'".into());
+            }
+            let name_regex = opt_str(input, "name_regex");
+            let not_name_matches: Vec<String> = input
+                .get("not_name_matches")
+                .and_then(Value::as_array)
+                .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+                .unwrap_or_default();
+            let limit  = u64_field(input, "limit", 1) as usize;
+            let scroll = bool_field(input, "scroll", false);
+
+            if scroll {
+                let scroll_max = u64_field(input, "scroll_max", 10) as usize;
+                let (node, scrolled) = crate::browser_ax::find_scrolling_by_role_and_name(
+                    role.as_deref(), name.as_deref(),
+                    name_regex.as_deref(), &not_name_matches,
+                    scroll_max, 400.0,
+                )?;
+                return Ok(json!({
+                    "found": node.is_some(),
+                    "node": node,
+                    "scrolled_times": scrolled,
+                }));
+            }
+
+            if limit <= 1 {
+                match crate::browser_ax::find_by_role_and_name(
+                    role.as_deref(), name.as_deref(),
+                    name_regex.as_deref(), &not_name_matches,
+                )? {
+                    Some(n) => Ok(json!({ "found": true,  "node": n    })),
+                    None    => Ok(json!({ "found": false, "node": null })),
+                }
+            } else {
+                let nodes = crate::browser_ax::find_all_by_role_and_name(
+                    role.as_deref(), name.as_deref(),
+                    name_regex.as_deref(), &not_name_matches, limit,
+                )?;
+                Ok(json!({
+                    "found": !nodes.is_empty(),
+                    "count": nodes.len(),
+                    "nodes": nodes,
+                }))
+            }
+        }
+        "ax_snapshot" => {
+            let snap_id = opt_str(input, "id");
+            let id = crate::browser_ax::ax_snapshot(snap_id.as_deref())?;
+            Ok(json!({ "snapshot_id": id }))
+        }
+        "ax_diff" => {
+            let before = input["before_id"].as_str().ok_or("'ax_diff' requires 'before_id'")?;
+            let after  = input["after_id"].as_str().ok_or("'ax_diff' requires 'after_id'")?;
+            let diff = crate::browser_ax::ax_diff(before, after)?;
+            Ok(json!({
+                "added_count":   diff.added.len(),
+                "removed_count": diff.removed.len(),
+                "changed_count": diff.changed.len(),
+                "added":   diff.added.iter().map(|n| json!({"node_id": n.node_id, "role": n.role, "name": n.name})).collect::<Vec<_>>(),
+                "removed": diff.removed.iter().map(|n| json!({"node_id": n.node_id, "role": n.role, "name": n.name})).collect::<Vec<_>>(),
+                "changed": diff.changed,
+            }))
+        }
+        "wait_for_ax_change" => {
+            let baseline_id = input["baseline_id"].as_str()
+                .ok_or("'wait_for_ax_change' requires 'baseline_id'")?;
+            let to_ms = input.get("timeout").and_then(Value::as_u64).unwrap_or(5000);
+            let (new_id, diff) = crate::browser_ax::wait_for_ax_change(baseline_id, to_ms)?;
+            Ok(json!({
+                "new_snapshot_id": new_id,
+                "added_count":   diff.added.len(),
+                "removed_count": diff.removed.len(),
+                "changed_count": diff.changed.len(),
+            }))
+        }
+        "ax_value" => {
+            let id = input.get("backend_id").and_then(Value::as_u64)
+                .ok_or("'ax_value' requires 'backend_id' (number)")? as u32;
+            Ok(json!({ "backend_id": id, "text": crate::browser_ax::read_node_text(id)? }))
+        }
+        "ax_click" => {
+            let id = input.get("backend_id").and_then(Value::as_u64)
+                .ok_or("'ax_click' requires 'backend_id' (number)")? as u32;
+            crate::browser_ax::click_backend(id)?;
+            Ok(json!({ "status": "clicked", "backend_id": id }))
+        }
+        "ax_focus" => {
+            let id = input.get("backend_id").and_then(Value::as_u64)
+                .ok_or("'ax_focus' requires 'backend_id' (number)")? as u32;
+            crate::browser_ax::focus_backend(id)?;
+            Ok(json!({ "status": "focused", "backend_id": id }))
+        }
+        "ax_type" => {
+            let id = input.get("backend_id").and_then(Value::as_u64)
+                .ok_or("'ax_type' requires 'backend_id' (number)")? as u32;
+            crate::browser_ax::type_into_backend(id, text)?;
+            Ok(json!({ "status": "typed", "backend_id": id, "length": text.len() }))
+        }
+        "ax_type_verified" => {
+            let id = input.get("backend_id").and_then(Value::as_u64)
+                .ok_or("'ax_type_verified' requires 'backend_id' (number)")? as u32;
+            let r = crate::browser_ax::type_into_backend_verified(id, text)?;
+            Ok(serde_json::to_value(&r).unwrap_or(json!({})))
+        }
+
+        // ── Test isolation ───────────────────────────────────────────────
+        "clear_state" => {
+            browser::clear_browser_state()?;
+            Ok(json!({ "status": "cleared" }))
+        }
+
+        // ── Flutter Shadow DOM ───────────────────────────────────────────
+        "shadow_find" => {
+            let role = opt_str(input, "role");
+            let name = opt_str2(input, "name_regex", "name").map(String::from);
+            let (x, y, label) = browser::shadow_find(role.as_deref(), name.as_deref())?;
+            Ok(json!({ "found": true, "x": x, "y": y, "label": label }))
+        }
+        "shadow_click" => {
+            let role = opt_str(input, "role");
+            let name = opt_str2(input, "name_regex", "name").map(String::from);
+            let label = browser::shadow_click(role.as_deref(), name.as_deref())?;
+            Ok(json!({ "status": "clicked", "label": label }))
+        }
+        "shadow_type" => {
+            let role = opt_str(input, "role");
+            let name = opt_str2(input, "name_regex", "name").map(String::from);
+            let text_val = input.get("text").and_then(Value::as_str)
+                .ok_or("'shadow_type' requires 'text'")?;
+            browser::shadow_type(role.as_deref(), name.as_deref(), text_val)?;
+            Ok(json!({ "status": "typed", "text": text_val }))
+        }
+        "flutter_type" => {
+            // Accept both string "50" and number 50 (sirin-call key=value parses ints as JSON numbers).
+            let text_owned = input.get("text")
+                .map(|v| if let Some(s) = v.as_str() { s.to_string() } else { v.to_string().trim_matches('"').to_string() })
+                .ok_or("'flutter_type' requires 'text'")?;
+            browser::flutter_type(&text_owned)?;
+            Ok(json!({ "status": "typed", "text": text_owned }))
+        }
+        "flutter_enter" => {
+            let result = browser::flutter_enter()?;
+            Ok(json!({ "status": "ok", "result": result }))
+        }
+        "shadow_type_flutter" => {
+            let role = opt_str(input, "role");
+            let name = opt_str2(input, "name_regex", "name").map(String::from);
+            let text_owned = input.get("text")
+                .map(|v| if let Some(s) = v.as_str() { s.to_string() } else { v.to_string().trim_matches('"').to_string() })
+                .ok_or("'shadow_type_flutter' requires 'text'")?;
+            let label = browser::shadow_click(role.as_deref(), name.as_deref())?;
+            std::thread::sleep(std::time::Duration::from_millis(350));
+            browser::flutter_type(&text_owned)?;
+            Ok(json!({ "status": "typed", "label": label, "text": text_owned }))
+        }
+        "shadow_dump" => {
+            let items = browser::shadow_dump()?;
+            Ok(json!({ "count": items.len(), "elements": items }))
+        }
+
+        // ── Multi-tab / popup ────────────────────────────────────────────
+        "wait_new_tab" => {
+            let to_ms = input.get("timeout").and_then(Value::as_u64).unwrap_or(10000);
+            let idx = browser::wait_for_new_tab(None, to_ms)?;
+            Ok(json!({ "status": "new tab opened", "active_tab": idx }))
+        }
+
+        // ── Network conditions ───────────────────────────────────────────
+        "wait_request" => {
+            if target.is_empty() {
+                return Err("'wait_request' requires 'target' = URL substring".into());
+            }
+            let to_ms = input.get("timeout").and_then(Value::as_u64).unwrap_or(10000);
+            let raw = browser::wait_for_request(target, to_ms)?;
+            let val: Value = serde_json::from_str(&raw).unwrap_or(json!({}));
+            Ok(json!({ "request": val }))
+        }
+
+        // ── Condition-based waits ────────────────────────────────────────
+        "wait_for_url" => {
+            if target.is_empty() {
+                return Err("'wait_for_url' requires 'target' (URL substring or /regex/)".into());
+            }
+            let to_ms = input.get("timeout_ms")
+                .or_else(|| input.get("timeout"))
+                .and_then(Value::as_u64)
+                .unwrap_or(10000);
+            let elapsed = browser::wait_for_url(target, to_ms)?;
+            let url = browser::current_url().unwrap_or_default();
+            Ok(json!({ "status": "ready", "elapsed_ms": elapsed, "url": url }))
+        }
+        "wait_for_ax_ready" => {
+            let min_nodes = input.get("min_nodes").and_then(Value::as_u64).unwrap_or(20) as usize;
+            let to_ms = input.get("timeout_ms")
+                .or_else(|| input.get("timeout"))
+                .and_then(Value::as_u64)
+                .unwrap_or(10000);
+            let (elapsed, count) = crate::browser_ax::wait_for_ax_ready(min_nodes, to_ms)?;
+            Ok(json!({ "status": "ready", "elapsed_ms": elapsed, "ax_node_count": count }))
+        }
+        "wait_for_network_idle" => {
+            let idle_ms = input.get("idle_ms").and_then(Value::as_u64).unwrap_or(500);
+            let to_ms = input.get("timeout_ms")
+                .or_else(|| input.get("timeout"))
+                .and_then(Value::as_u64)
+                .unwrap_or(15000);
+            let elapsed = browser::wait_for_network_idle(idle_ms, to_ms)?;
+            Ok(json!({ "status": "idle", "elapsed_ms": elapsed }))
+        }
+
+        // ── Assertions ───────────────────────────────────────────────────
+        "assert_ax_contains" => {
+            if target.is_empty() {
+                return Err("'assert_ax_contains' requires 'target' = text to find".into());
+            }
+            let tree = crate::browser_ax::get_full_tree(false)?;
+            let needle = target.to_lowercase();
+            let found = tree.iter().any(|n| {
+                n.name.as_deref().unwrap_or("").to_lowercase().contains(&needle)
+                    || n.value.as_deref().unwrap_or("").to_lowercase().contains(&needle)
+            });
+            let preview: Vec<String> = tree.iter().take(20)
+                .filter_map(|n| n.name.clone().or_else(|| n.value.clone()))
+                .collect();
+            Ok(json!({
+                "passed":                 found,
+                "target":                 target,
+                "actual_ax_tree_preview": preview.join(" | "),
+            }))
+        }
+        "assert_url_matches" => {
+            if target.is_empty() {
+                return Err("'assert_url_matches' requires 'target' (URL substring or /regex/)".into());
+            }
+            let url = browser::current_url().unwrap_or_default();
+            let is_regex = target.starts_with('/') && target.ends_with('/') && target.len() > 2;
+            let passed = if is_regex {
+                let pattern = &target[1..target.len() - 1];
+                regex::Regex::new(pattern).map(|re| re.is_match(&url)).unwrap_or(false)
+            } else {
+                url.contains(target)
+            };
+            Ok(json!({ "passed": passed, "target": target, "actual_url": url }))
+        }
+
+        // ── Named sessions ───────────────────────────────────────────────
+        "list_sessions" => {
+            let sessions = browser::list_sessions().unwrap_or_default();
+            let items: Vec<Value> = sessions.into_iter().map(|(id, idx, url)| {
+                json!({ "session_id": id, "tab_index": idx, "url": url })
+            }).collect();
+            Ok(json!({ "count": items.len(), "sessions": items }))
+        }
+        "close_session" => {
+            if target.is_empty() {
+                return Err("'close_session' requires 'target' = session_id".into());
+            }
+            browser::close_session(target)?;
+            Ok(json!({ "status": "closed", "session_id": target }))
+        }
+
+        other => Err(format!("Unknown browser action: {other}")),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ pub mod error;
 mod platform;
 #[allow(dead_code)] mod browser;
 #[allow(dead_code)] mod browser_ax;
+#[allow(dead_code)] mod browser_exec;
 #[allow(dead_code)] mod claude_session;
 #[allow(dead_code)] mod multi_agent;
 #[allow(dead_code)] mod config_check;

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -1779,28 +1779,14 @@ async fn call_browser_exec(args: Value, user_agent: &str) -> Result<Value, Strin
     let t0 = std::time::Instant::now();
 
     let action = args["action"].as_str().ok_or("Missing action")?.to_string();
-    let target = args.get("target").and_then(Value::as_str).unwrap_or("").to_string();
-    let text   = args.get("text").and_then(Value::as_str).unwrap_or("").to_string();
+    // target / text / timeout are kept for the screenshot_analyze / ocr_find_text
+    // async-only handlers below; all other parameter parsing is done inside
+    // browser_exec::dispatch() which reads them from the raw `args` Value.
+    let target  = args.get("target").and_then(Value::as_str).unwrap_or("").to_string();
     let timeout = args.get("timeout").and_then(Value::as_u64);
     let headless_override = args.get("browser_headless").and_then(Value::as_bool);
-    // Coord args for click_point; viewport args for set_viewport.  Fixes #11.
-    let x = args.get("x").and_then(Value::as_f64);
-    let y = args.get("y").and_then(Value::as_f64);
-    let width = args.get("width").and_then(Value::as_u64);
-    let height = args.get("height").and_then(Value::as_u64);
-    let device_scale = args.get("device_scale").and_then(Value::as_f64).unwrap_or(1.0);
-    let mobile = args.get("mobile").and_then(Value::as_bool).unwrap_or(false);
-    // ax_* args
-    let backend_id = args.get("backend_id").and_then(Value::as_u64).map(|n| n as u32);
-    let role_arg = args.get("role").and_then(Value::as_str).map(String::from);
-    let name_arg = args.get("name").and_then(Value::as_str).map(String::from);
-    let include_ignored = args.get("include_ignored").and_then(Value::as_bool).unwrap_or(false);
-    // Issue #19 new args
+    // session_id pre-processing happens inside the blocking closure below.
     let session_id_arg = args.get("session_id").and_then(Value::as_str).map(String::from);
-    let scroll_arg = args.get("scroll").and_then(Value::as_bool).unwrap_or(false);
-    let scroll_max_arg = args.get("scroll_max").and_then(Value::as_u64).unwrap_or(10) as usize;
-    let min_nodes_arg = args.get("min_nodes").and_then(Value::as_u64).unwrap_or(20) as usize;
-    let idle_ms_arg = args.get("idle_ms").and_then(Value::as_u64).unwrap_or(500);
 
     // ── Async-only actions (need LLM call, can't go in spawn_blocking) ────
     if action == "screenshot_analyze" {
@@ -1853,8 +1839,8 @@ async fn call_browser_exec(args: Value, user_agent: &str) -> Result<Value, Strin
         }
     }
 
-    // Dispatch directly to crate::browser to avoid requiring an AgentContext
-    // for simple imperative calls.  Mirrors the web_navigate action set.
+    // Dispatch via the shared browser_exec module.  All common browser actions
+    // live there; only MCP-specific ext_* probes are handled inline below.
     let result = blocking("browser_exec_sync", move || -> Result<Value, String> {
         use crate::browser;
         let want_headless = headless_override.unwrap_or_else(browser::default_headless);
@@ -1869,409 +1855,31 @@ async fn call_browser_exec(args: Value, user_agent: &str) -> Result<Value, Strin
             browser::session_switch(sid)?;
         }
 
+        // ── Sirin Companion extension probes (MCP-only, not in browser_exec) ──
         match action.as_str() {
-            "goto" => {
-                if target.is_empty() { return Err("'goto' requires 'target' URL".into()); }
-                browser::ensure_open(want_headless)?;
-                browser::navigate(&target)?;
-                Ok(json!({ "status": "navigated", "url": target }))
-            }
-            "screenshot" => {
-                let png = browser::screenshot()?;
-                let b64 = base64_encode(&png);
-                let url = browser::current_url().unwrap_or_default();
-                Ok(json!({
-                    "mime": "image/png",
-                    "bytes_base64": b64,
-                    "size_bytes": png.len(),
-                    "url": url,
-                }))
-            }
-            "click" => {
-                if target.is_empty() { return Err("'click' requires 'target' selector".into()); }
-                browser::click(&target)?;
-                Ok(json!({ "status": "clicked", "selector": target }))
-            }
-            "type" => {
-                if target.is_empty() { return Err("'type' requires 'target' selector".into()); }
-                browser::type_text(&target, &text)?;
-                Ok(json!({ "status": "typed", "selector": target, "length": text.len() }))
-            }
-            "read" => {
-                if target.is_empty() { return Err("'read' requires 'target' selector".into()); }
-                Ok(json!({ "selector": target, "text": browser::get_text(&target)? }))
-            }
-            "eval" => {
-                if target.is_empty() { return Err("'eval' requires 'target' JS expression".into()); }
-                Ok(json!({ "result": browser::evaluate_js(&target)? }))
-            }
-            "go_back" => {
-                let wait_ms = args.get("wait").and_then(Value::as_u64).unwrap_or(0);
-                browser::go_back(wait_ms)?;
-                let url = browser::current_url().unwrap_or_default();
-                Ok(json!({ "status": "went_back", "url": url }))
-            }
-            "wait" => {
-                if target.is_empty() { return Err("'wait' requires 'target' selector".into()); }
-                browser::wait_for_ms(&target, timeout.unwrap_or(5000))?;
-                Ok(json!({ "status": "found", "selector": target }))
-            }
-            "exists" => {
-                if target.is_empty() { return Err("'exists' requires 'target' selector".into()); }
-                Ok(json!({ "selector": target, "exists": browser::element_exists(&target)? }))
-            }
-            "attr" => {
-                if target.is_empty() { return Err("'attr' requires 'target' selector".into()); }
-                if text.is_empty() { return Err("'attr' requires 'text' = attribute name".into()); }
-                Ok(json!({ "selector": target, "attribute": &text, "value": browser::get_attribute(&target, &text)? }))
-            }
-            "scroll" => {
-                let y = timeout.map(|t| t as f64).unwrap_or(300.0);
-                browser::scroll_by(0.0, y)?;
-                Ok(json!({ "status": "scrolled", "y": y }))
-            }
-            "key" => {
-                if target.is_empty() { return Err("'key' requires 'target' key name".into()); }
-                browser::press_key(&target)?;
-                Ok(json!({ "status": "pressed", "key": target }))
-            }
-            "console" => {
-                let limit = timeout.unwrap_or(20) as usize;
-                let raw = browser::console_messages(limit).unwrap_or_else(|_| "[]".into());
-                let val: Value = serde_json::from_str(&raw).unwrap_or(json!([]));
-                Ok(json!({ "messages": val }))
-            }
-            "network" => {
-                let limit = timeout.unwrap_or(20) as usize;
-                let raw = browser::captured_requests(limit).unwrap_or_else(|_| "[]".into());
-                let val: Value = serde_json::from_str(&raw).unwrap_or(json!([]));
-                Ok(json!({ "requests": val }))
-            }
-            "url"   => Ok(json!({ "url": browser::current_url()? })),
-            "title" => Ok(json!({ "title": browser::page_title()? })),
-            "close" => { browser::close(); Ok(json!({ "status": "closed" })) }
-            // Fixes #11: expose click_point + set_viewport so Flutter Web / CanvasKit
-            // apps (no DOM) can be driven by coordinate rather than CSS selector.
-            "click_point" => {
-                let cx = x.ok_or("'click_point' requires 'x' (number)")?;
-                let cy = y.ok_or("'click_point' requires 'y' (number)")?;
-                // Issue #79: HiDPI screenshot coords need devicePixelRatio rescaling.
-                let source = args.get("coord_source").and_then(Value::as_str).unwrap_or("css");
-                match source {
-                    "screenshot" => browser::click_point_screenshot(cx, cy)?,
-                    _ => browser::click_point(cx, cy)?,
-                }
-                Ok(json!({ "status": "clicked", "x": cx, "y": cy, "coord_source": source }))
-            }
-            "set_viewport" => {
-                let w = width.ok_or("'set_viewport' requires 'width' (positive integer)")? as u32;
-                let h = height.ok_or("'set_viewport' requires 'height' (positive integer)")? as u32;
-                browser::set_viewport(w, h, device_scale, mobile)?;
-                Ok(json!({
-                    "status": "viewport set",
-                    "width": w, "height": h,
-                    "device_scale": device_scale, "mobile": mobile
-                }))
-            }
-            // ── Accessibility tree (literal text — for exact assertions) ──
-            "enable_a11y" => {
-                // Always call enable_flutter_semantics() to trigger the placeholder click
-                // that builds flt-semantics-host DOM elements (used by shadow_find/shadow_dump).
-                // Safety net: detect about:blank URL reset and restore.
-                let saved_url = crate::browser::current_url().ok();
-                let _ = crate::browser_ax::enable_flutter_semantics();
-                // Poll until flt-semantics-host is non-empty (Flutter fills it async).
-                let mut shadow_ready = false;
-                for _ in 0..15 {
-                    let count = browser::evaluate_js(
-                        "document.querySelector('flt-semantics-host')?.childElementCount||0"
-                    ).unwrap_or_default();
-                    if count.trim() != "0" {
-                        shadow_ready = true;
-                        break;
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(200));
-                }
-                if let Some(ref url) = saved_url {
-                    let cur = crate::browser::current_url().unwrap_or_default();
-                    if cur.contains("about:blank") && !url.contains("about:blank") && !url.is_empty() {
-                        tracing::warn!(
-                            "[browser_ax] enable_a11y: URL reset detected (about:blank) — restoring {url:?}"
-                        );
-                        let _ = crate::browser::navigate(url);
-                        std::thread::sleep(std::time::Duration::from_millis(500));
-                    }
-                }
-                let tree = crate::browser_ax::get_full_tree(false).unwrap_or_default();
-                Ok(json!({ "status": "semantics enabled", "ax_node_count": tree.len(), "shadow_ready": shadow_ready }))
-            }
-            "ax_tree" => {
-                let nodes = crate::browser_ax::get_full_tree(include_ignored)?;
-                Ok(json!({ "count": nodes.len(), "nodes": nodes }))
-            }
-            "ax_find" => {
-                if role_arg.is_none() && name_arg.is_none() {
-                    return Err("'ax_find' requires 'role' and/or 'name'".into());
-                }
-                let name_regex_arg = args.get("name_regex").and_then(Value::as_str).map(String::from);
-                let not_name_matches: Vec<String> = args.get("not_name_matches")
-                    .and_then(Value::as_array)
-                    .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
-                    .unwrap_or_default();
-                let limit = args.get("limit").and_then(Value::as_u64).unwrap_or(1) as usize;
-
-                // scroll=true: scroll-aware find (Issue #19 P1)
-                if scroll_arg {
-                    let (node, scrolled) = crate::browser_ax::find_scrolling_by_role_and_name(
-                        role_arg.as_deref(), name_arg.as_deref(),
-                        name_regex_arg.as_deref(), &not_name_matches,
-                        scroll_max_arg, 400.0,
-                    )?;
-                    return Ok(json!({
-                        "found": node.is_some(),
-                        "node": node,
-                        "scrolled_times": scrolled,
-                    }));
-                }
-
-                if limit <= 1 {
-                    match crate::browser_ax::find_by_role_and_name(
-                        role_arg.as_deref(), name_arg.as_deref(),
-                        name_regex_arg.as_deref(), &not_name_matches,
-                    )? {
-                        Some(node) => Ok(json!({ "found": true, "node": node })),
-                        None => Ok(json!({ "found": false, "node": null })),
-                    }
-                } else {
-                    let nodes = crate::browser_ax::find_all_by_role_and_name(
-                        role_arg.as_deref(), name_arg.as_deref(),
-                        name_regex_arg.as_deref(), &not_name_matches, limit,
-                    )?;
-                    Ok(json!({
-                        "found": !nodes.is_empty(),
-                        "count": nodes.len(),
-                        "nodes": nodes,
-                    }))
-                }
-            }
-            "ax_snapshot" => {
-                let snap_id_arg = args.get("id").and_then(Value::as_str).map(String::from);
-                let id = crate::browser_ax::ax_snapshot(snap_id_arg.as_deref())?;
-                Ok(json!({ "snapshot_id": id }))
-            }
-            "ax_diff" => {
-                let before = args["before_id"].as_str().ok_or("'ax_diff' requires 'before_id'")?;
-                let after  = args["after_id"].as_str().ok_or("'ax_diff' requires 'after_id'")?;
-                let diff = crate::browser_ax::ax_diff(before, after)?;
-                Ok(json!({
-                    "added_count":   diff.added.len(),
-                    "removed_count": diff.removed.len(),
-                    "changed_count": diff.changed.len(),
-                    "added":   diff.added.iter().map(|n| json!({"node_id": n.node_id, "role": n.role, "name": n.name})).collect::<Vec<_>>(),
-                    "removed": diff.removed.iter().map(|n| json!({"node_id": n.node_id, "role": n.role, "name": n.name})).collect::<Vec<_>>(),
-                    "changed": diff.changed,
-                }))
-            }
-            "wait_for_ax_change" => {
-                let baseline_id = args["baseline_id"].as_str().ok_or("'wait_for_ax_change' requires 'baseline_id'")?;
-                let to_ms = timeout.unwrap_or(5000);
-                let (new_id, diff) = crate::browser_ax::wait_for_ax_change(baseline_id, to_ms)?;
-                Ok(json!({
-                    "new_snapshot_id": new_id,
-                    "added_count":   diff.added.len(),
-                    "removed_count": diff.removed.len(),
-                    "changed_count": diff.changed.len(),
-                }))
-            }
-            "ax_value" => {
-                let id = backend_id.ok_or("'ax_value' requires 'backend_id' (number)")?;
-                Ok(json!({ "backend_id": id, "text": crate::browser_ax::read_node_text(id)? }))
-            }
-            "ax_click" => {
-                let id = backend_id.ok_or("'ax_click' requires 'backend_id' (number)")?;
-                crate::browser_ax::click_backend(id)?;
-                Ok(json!({ "status": "clicked", "backend_id": id }))
-            }
-            "ax_focus" => {
-                let id = backend_id.ok_or("'ax_focus' requires 'backend_id' (number)")?;
-                crate::browser_ax::focus_backend(id)?;
-                Ok(json!({ "status": "focused", "backend_id": id }))
-            }
-            "ax_type" => {
-                let id = backend_id.ok_or("'ax_type' requires 'backend_id' (number)")?;
-                crate::browser_ax::type_into_backend(id, &text)?;
-                Ok(json!({ "status": "typed", "backend_id": id, "length": text.len() }))
-            }
-            "ax_type_verified" => {
-                let id = backend_id.ok_or("'ax_type_verified' requires 'backend_id' (number)")?;
-                let r = crate::browser_ax::type_into_backend_verified(id, &text)?;
-                Ok(serde_json::to_value(&r).unwrap_or(json!({})))
-            }
-            // ── Test isolation ──────────────────────────────────────
-            "clear_state" => {
-                browser::clear_browser_state()?;
-                Ok(json!({ "status": "cleared" }))
-            }
-            // ── Flutter Shadow DOM ──────────────────────────────────────────
-            "shadow_find" => {
-                let role = args.get("role").and_then(Value::as_str).map(String::from);
-                let name = args.get("name_regex").or_else(|| args.get("name"))
-                    .and_then(Value::as_str).map(String::from);
-                let (x, y, label) = browser::shadow_find(role.as_deref(), name.as_deref())?;
-                Ok(json!({ "found": true, "x": x, "y": y, "label": label }))
-            }
-            "shadow_click" => {
-                let role = args.get("role").and_then(Value::as_str).map(String::from);
-                let name = args.get("name_regex").or_else(|| args.get("name"))
-                    .and_then(Value::as_str).map(String::from);
-                let label = browser::shadow_click(role.as_deref(), name.as_deref())?;
-                Ok(json!({ "status": "clicked", "label": label }))
-            }
-            "shadow_type" => {
-                let role = args.get("role").and_then(Value::as_str).map(String::from);
-                let name = args.get("name_regex").or_else(|| args.get("name"))
-                    .and_then(Value::as_str).map(String::from);
-                let text_val = args.get("text").and_then(Value::as_str)
-                    .ok_or("'shadow_type' requires 'text'")?;
-                browser::shadow_type(role.as_deref(), name.as_deref(), text_val)?;
-                Ok(json!({ "status": "typed", "text": text_val }))
-            }
-            "flutter_type" => {
-                // Accept both string "50" and number 50 (sirin-call key=value parses ints as JSON numbers)
-                let text_owned = args.get("text")
-                    .map(|v| if let Some(s) = v.as_str() { s.to_string() } else { v.to_string().trim_matches('"').to_string() })
-                    .ok_or("'flutter_type' requires 'text'")?;
-                browser::flutter_type(&text_owned)?;
-                Ok(json!({ "status": "typed", "text": text_owned }))
-            }
-            "flutter_enter" => {
-                // Send Enter key to flt-text-editing — submits chat message or form
-                let result = browser::flutter_enter()?;
-                Ok(json!({ "status": "ok", "result": result }))
-            }
-            "shadow_type_flutter" => {
-                let role = args.get("role").and_then(Value::as_str).map(String::from);
-                let name = args.get("name_regex").or_else(|| args.get("name"))
-                    .and_then(Value::as_str).map(String::from);
-                let text_owned = args.get("text")
-                    .map(|v| if let Some(s) = v.as_str() { s.to_string() } else { v.to_string().trim_matches('"').to_string() })
-                    .ok_or("'shadow_type_flutter' requires 'text'")?;
-                let label = browser::shadow_click(role.as_deref(), name.as_deref())?;
-                std::thread::sleep(std::time::Duration::from_millis(350));
-                browser::flutter_type(&text_owned)?;
-                Ok(json!({ "status": "typed", "label": label, "text": text_owned }))
-            }
-            "shadow_dump" => {
-                let items = browser::shadow_dump()?;
-                Ok(json!({ "count": items.len(), "elements": items }))
-            }
-            // ── Multi-tab / popup ───────────────────────────────────
-            "wait_new_tab" => {
-                let to_ms = timeout.unwrap_or(10000);
-                // baseline=None → fn measures from same source as its loop
-                let idx = browser::wait_for_new_tab(None, to_ms)?;
-                Ok(json!({ "status": "new tab opened", "active_tab": idx }))
-            }
-            // ── Network ─────────────────────────────────────────────
-            "wait_request" => {
-                if target.is_empty() {
-                    return Err("'wait_request' requires 'target' = URL substring".into());
-                }
-                let to_ms = timeout.unwrap_or(10000);
-                let raw = browser::wait_for_request(&target, to_ms)?;
-                let val: Value = serde_json::from_str(&raw).unwrap_or(json!({}));
-                Ok(json!({ "request": val }))
-            }
-            // ── Condition-based waits (Issue #19 P0) ─────────────────
-            "wait_for_url" => {
-                if target.is_empty() {
-                    return Err("'wait_for_url' requires 'target' (URL substring or /regex/)".into());
-                }
-                let to_ms = timeout.unwrap_or(10000);
-                let elapsed = browser::wait_for_url(&target, to_ms)?;
-                let url = browser::current_url().unwrap_or_default();
-                Ok(json!({ "status": "ready", "elapsed_ms": elapsed, "url": url }))
-            }
-            "wait_for_ax_ready" => {
-                let to_ms = timeout.unwrap_or(10000);
-                let (elapsed, count) = crate::browser_ax::wait_for_ax_ready(min_nodes_arg, to_ms)?;
-                Ok(json!({ "status": "ready", "elapsed_ms": elapsed, "ax_node_count": count }))
-            }
-            "wait_for_network_idle" => {
-                let to_ms = timeout.unwrap_or(15000);
-                let elapsed = browser::wait_for_network_idle(idle_ms_arg, to_ms)?;
-                Ok(json!({ "status": "idle", "elapsed_ms": elapsed }))
-            }
-            // ── Assertions (Issue #19 bonus) ──────────────────────────
-            "assert_ax_contains" => {
-                if target.is_empty() {
-                    return Err("'assert_ax_contains' requires 'target' = text to find".into());
-                }
-                let tree = crate::browser_ax::get_full_tree(false)?;
-                let needle = target.to_lowercase();
-                let found = tree.iter().any(|n| {
-                    n.name.as_deref().unwrap_or("").to_lowercase().contains(&needle)
-                        || n.value.as_deref().unwrap_or("").to_lowercase().contains(&needle)
-                });
-                let preview: Vec<String> = tree.iter().take(20)
-                    .filter_map(|n| n.name.clone().or_else(|| n.value.clone()))
-                    .collect();
-                Ok(json!({
-                    "passed": found,
-                    "target": target,
-                    "actual_ax_tree_preview": preview.join(" | "),
-                }))
-            }
-            "assert_url_matches" => {
-                if target.is_empty() {
-                    return Err("'assert_url_matches' requires 'target' (URL substring or /regex/)".into());
-                }
-                let url = browser::current_url().unwrap_or_default();
-                let is_regex = target.starts_with('/') && target.ends_with('/') && target.len() > 2;
-                let passed = if is_regex {
-                    let pattern = &target[1..target.len() - 1];
-                    regex::Regex::new(pattern).map(|re| re.is_match(&url)).unwrap_or(false)
-                } else {
-                    url.contains(&target)
-                };
-                Ok(json!({ "passed": passed, "target": target, "actual_url": url }))
-            }
-            // ── Named sessions (Issue #19 P1) ─────────────────────────
-            "list_sessions" => {
-                let sessions = browser::list_sessions().unwrap_or_default();
-                let items: Vec<Value> = sessions.into_iter().map(|(id, idx, url)| {
-                    json!({ "session_id": id, "tab_index": idx, "url": url })
-                }).collect();
-                Ok(json!({ "count": items.len(), "sessions": items }))
-            }
-            "close_session" => {
-                if target.is_empty() {
-                    return Err("'close_session' requires 'target' = session_id".into());
-                }
-                browser::close_session(&target)?;
-                Ok(json!({ "status": "closed", "session_id": target }))
-            }
-            // ── Sirin Companion extension probes (POC) ───────────────────────
             "ext_status" => {
-                Ok(serde_json::to_value(crate::ext_server::status())
-                    .map_err(|e| format!("ext_status serialize: {e}"))?)
+                return Ok(serde_json::to_value(crate::ext_server::status())
+                    .map_err(|e| format!("ext_status serialize: {e}"))?);
             }
             "ext_url" => {
                 // Authoritative URL from extension; falls back to CDP cache.
                 let tab_id = args.get("tab_id").and_then(Value::as_i64);
-                match crate::ext_server::authoritative_url(tab_id) {
+                return match crate::ext_server::authoritative_url(tab_id) {
                     Some(u) => Ok(json!({ "url": u, "source": "extension" })),
                     None    => Ok(json!({
                         "url":    browser::current_url().unwrap_or_default(),
                         "source": "cdp_cache_fallback",
                     })),
-                }
+                };
             }
             "ext_tabs" => {
-                Ok(json!({ "tabs": crate::ext_server::list_tabs() }))
+                return Ok(json!({ "tabs": crate::ext_server::list_tabs() }));
             }
-            other   => Err(format!("Unknown browser_exec action: {other}")),
+            _ => {}
         }
+
+        // ── All other actions: shared dispatch ────────────────────────────
+        crate::browser_exec::dispatch(action.as_str(), &args)
     })
     .await;
 


### PR DESCRIPTION
## Summary

- 新建 `src/browser_exec.rs`，提供 `pub(crate) dispatch(action, input)` 單一入口點，作為 mcp_server 與 web_navigate builtin 的共用 browser action 分發層
- `mcp_server.rs` 的 ~420 行 match block → 3 行 ext_* 特例 + 1 行 `browser_exec::dispatch()` 呼叫
- `builtins.rs` 的 ~640 行 match block → 5 個 test-runner 特例（goto + authz、screenshot + event、dom_snapshot、ax_tree diff mode、screenshot_analyze sentinel）+ 1 行 `browser_exec::dispatch()` 呼叫
- `resolve_target()` helper（builtins 內部用）已整合進 `browser_exec::resolve_selector()`，dead code 移除

## Actions gained by mcp_server from the merge

透過共用 dispatch，mcp_server 現在自動擁有 builtins 原有的這些 action：
`dom_snapshot`, `count`, `value`, `select`, `scroll_to`, `hover`, `hover_point`, `new_tab`, `switch_tab`, `close_tab`, `list_tabs`, `cookies`, `set_cookie`, `delete_cookie`, `localStorage_get`, `localStorage_set`, `install_capture`, `viewport`, `pdf`, `drag`, `http_auth`

另外 `scroll` 統一為 `x`/`y` 兩軸參數（之前 mcp_server 只支援 y 軸）。

## Test plan

- [x] `cargo check --bin sirin` — 0 errors, 0 warnings
- [x] `cargo test --bin sirin` — 401 passed, 0 failed, 17 ignored
- [x] `bash scripts/preflight.sh` section 6 — `✅ all browser actions registered in builtins.rs (or shared browser_exec.rs)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)