### PR TITLE
docs(scripts): #253 fetch-handoff.sh reference with token-security hardening

### DIFF
--- a/scripts/fetch-handoff.sh.example
+++ b/scripts/fetch-handoff.sh.example
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# ─── Reference copy of ~/.claude/scripts/fetch-handoff.sh ───────────────────
+#
+# This is the script every new Claude Code session runs as part of its
+# SessionStart hook to inject the latest mid-session handoff (KB topic
+# `sirin-handoff-latest`) into the new session's context. See CLAUDE.md
+# (root) for the broader handoff workflow.
+#
+# Install:
+#   mkdir -p ~/.claude/scripts
+#   cp scripts/fetch-handoff.sh.example ~/.claude/scripts/fetch-handoff.sh
+#   chmod +x ~/.claude/scripts/fetch-handoff.sh
+#
+# Wire into ~/.claude/settings.json under hooks.SessionStart so the script
+# emits the handoff to stdout — the harness injects it into the new session.
+#
+# Fetch latest handoff — tries Sirin MCP first (local, fast, no auth needed),
+# falls back to agora-trading KB (original method).
+#
+# Usage: fetch-handoff.sh [project]
+#   defaults: project=sirin
+#
+# Designed for SessionStart hook — fail-safe (silent exit on any error,
+# never blocks session startup).
+#
+# Security (Sirin #253):
+# - umask 077 — any temp files we create are mode 600
+# - Bearer tokens from ~/.claude.json never enter shell vars or process args
+# - Tokens are written to a 600 tempfile and consumed via `curl -K <file>`
+#   (curl reads -H lines from the config file, so tokens never appear in
+#   `ps aux` / cmdline / /proc/$PID/environ)
+# - tempfile is shredded + removed via trap on EXIT
+
+set +e
+umask 077
+
+PROJECT="${1:-sirin}"
+SIRIN_URL="http://127.0.0.1:7700/mcp"
+KB_URL="https://agoramarketapi.purrtechllc.com/api/mcp"
+TIMEOUT=5
+
+# ── Path 1: Sirin MCP (local, no auth, instant) ──────────────────────────────
+RESP=$(curl -sL -X POST "$SIRIN_URL" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    --max-time "$TIMEOUT" \
+    -d "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"get_latest_handoff\",\"arguments\":{\"project\":\"$PROJECT\"}},\"id\":1}" 2>/dev/null)
+
+if [ -n "$RESP" ]; then
+    # Extract content field from JSON response (already unescaped, plain markdown)
+    CONTENT=$(echo "$RESP" | python -c "
+import sys, json
+raw = sys.stdin.read().strip()
+try:
+    for line in raw.split('\n'):
+        line = line.strip()
+        if line.startswith('data: '): line = line[6:]
+        if not line.startswith('{'): continue
+        d = json.loads(line)
+        r = d.get('result', {})
+        if r.get('isError'): continue
+        for item in r.get('content', []):
+            text = item.get('text', '')
+            try:
+                obj = json.loads(text)
+                c = obj.get('content', '')
+                if c:
+                    sys.stdout.write('=== KB handoff: sirin-handoff-latest ===\n')
+                    sys.stdout.write(c)
+                    sys.stdout.write('\n\n')
+                    sys.exit(0)
+            except: pass
+except: pass
+" 2>/dev/null)
+    if [ -n "$CONTENT" ]; then
+        echo "$CONTENT"
+        exit 0
+    fi
+fi
+
+# ── Path 2: agora-trading KB (fallback, needs dual bearer + unescape) ────────
+#
+# Token security (Sirin #253):
+# Instead of:
+#     TRADING_TOKEN=$(read_tok ...); curl -H "Authorization: $TRADING_TOKEN" ...
+# we write headers to a 600-mode tempfile and use `curl -K <file>` so tokens
+# never appear in argv. The python helper writes directly to the tempfile;
+# stdout never carries the token.
+
+CFG=""
+cleanup() {
+    if [ -n "$CFG" ] && [ -f "$CFG" ]; then
+        # Best-effort overwrite then remove. Not all systems have shred; ignore err.
+        command -v shred >/dev/null 2>&1 && shred -u "$CFG" 2>/dev/null
+        rm -f "$CFG" 2>/dev/null
+    fi
+}
+trap cleanup EXIT INT TERM
+
+CFG=$(mktemp 2>/dev/null) || exit 0
+chmod 600 "$CFG" 2>/dev/null
+
+# Write curl config (header lines) — python reads ~/.claude.json and writes
+# directly to $CFG, so tokens never traverse shell vars or stdout pipes.
+CLAUDE_JSON="$HOME/.claude.json" CFG_PATH="$CFG" python -c "
+import json, os, sys
+cfg_path = os.environ['CFG_PATH']
+try:
+    with open(os.path.expanduser(os.environ['CLAUDE_JSON']), encoding='utf-8') as f:
+        d = json.load(f)
+    trading = d['mcpServers']['agora-trading']['headers']['Authorization']
+    ops = d['mcpServers']['agora-ops']['headers']['Authorization']
+except Exception:
+    sys.exit(1)
+# curl -K config format: 'header = \"Name: value\"'
+with open(cfg_path, 'w', encoding='utf-8') as f:
+    f.write('header = \"Authorization: ' + trading + '\"\n')
+    f.write('header = \"X-OPS-Authorization: ' + ops + '\"\n')
+" 2>/dev/null
+
+# If the python step failed, the config file is empty — bail out silently.
+[ -s "$CFG" ] || exit 0
+
+RESP=$(curl -sL -X POST "$KB_URL" \
+    -K "$CFG" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "Content-Type: application/json" \
+    --max-time "$TIMEOUT" \
+    -d "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"kbGet\",\"arguments\":{\"topicKey\":\"sirin-handoff-latest\",\"project\":\"$PROJECT\"}},\"id\":1}" 2>/dev/null)
+
+[ -z "$RESP" ] && exit 0
+
+echo "$RESP" | TOPIC="sirin-handoff-latest" python -c "
+import sys, json, os
+topic = os.environ.get('TOPIC', '?')
+raw = sys.stdin.buffer.read().decode('utf-8', errors='replace').strip()
+try:
+    for line in raw.split('\n'):
+        line = line.strip()
+        if line.startswith('data: '): line = line[6:]
+        if not line.startswith('{'): continue
+        d = json.loads(line)
+        r = d.get('result', {})
+        if r.get('isError'): continue
+        for item in r.get('content', []):
+            text = item.get('text', '')
+            if len(text) >= 2 and text.startswith('\"') and text.endswith('\"'):
+                text = text[1:-1]
+            text = text.replace('\\\\\\\\', '\x00').replace('\\\\n', '\n').replace('\\\\\"', '\"').replace('\x00', '\\\\')
+            sys.stdout.buffer.write(f'=== KB handoff: {topic} ===\n'.encode('utf-8'))
+            sys.stdout.buffer.write(text.encode('utf-8', errors='replace'))
+            sys.stdout.buffer.write(b'\n\n')
+        break
+except Exception:
+    pass
+" 2>/dev/null
+
+exit 0

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -576,6 +576,34 @@ fn handle_tools_list() -> Result<Value, String> {
                 }
             },
             {
+                "name": "discover_app",
+                "description": "Issue #247 — 啟動自動探索爬蟲。Sirin 開瀏覽器到 seed_url，用 dom_snapshot 列舉可互動元件（button/link/input/tab），存到 SQLite discovered_features 表。\n\n用於 Coverage 3-tier funnel 的「探索」層 — 補 YAML coverage map 沒列到的功能。\n\n回傳 run_id（立即返回，crawl 在背景跑）。用 discovery_status 查狀態。",
+                "inputSchema": {
+                    "type": "object",
+                    "required": ["seed_url"],
+                    "properties": {
+                        "seed_url":  { "type": "string", "description": "起始 URL（爬蟲第一個導覽到的頁面）" },
+                        "max_depth": { "type": "number", "description": "遞迴深度上限（iter 2 只支援 1，更深需後續 PR）" }
+                    }
+                }
+            },
+            {
+                "name": "discovery_status",
+                "description": "查最近一次 discovery 爬蟲狀態。回傳 status (running/done/failed)、started_at、finished_at、total_widgets、累計 distinct features 數。",
+                "inputSchema": { "type": "object", "properties": {} }
+            },
+            {
+                "name": "discovery_features",
+                "description": "列出 discovery 爬蟲找到的所有 features（route/label/kind/selector/last_seen）。可用 limit + kind 過濾。",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "limit": { "type": "number", "description": "回傳上限，預設 100" },
+                        "kind":  { "type": "string", "description": "選填：只看某個 kind（button/link/form_input/tab/menuitem）" }
+                    }
+                }
+            },
+            {
                 "name": "list_flaky_tests",
                 "description": "列出歷史上不穩定（flaky）的測試，依 pass rate 升序（最差優先）。\n\n等同 test_analytics 但只回傳 flaky 條目，方便快速定位需要重點關注的測試。\n\nflaky 定義：近 10 次中 pass rate < threshold（預設 70%）且至少 3 次 runs。",
                 "inputSchema": {
@@ -1378,6 +1406,9 @@ async fn handle_tools_call(params: Value, user_agent: &str) -> Result<Value, Str
         "test_summary"         => return call_test_summary(arguments).map(wrap_json),
         "list_flaky_tests"        => return call_list_flaky_tests(arguments).map(wrap_json),
         "test_coverage"           => return call_test_coverage(arguments).map(wrap_json),
+        "discover_app"            => return call_discover_app(arguments).map(wrap_json),
+        "discovery_status"        => return call_discovery_status().map(wrap_json),
+        "discovery_features"      => return call_discovery_features(arguments).map(wrap_json),
         "replay_last_failure"     => return call_replay_last_failure(arguments).map(wrap_json),
         "shadow_dump_diff"        => return call_shadow_dump_diff(arguments).map(wrap_json),
         "compare_with_replay"     => return call_compare_with_replay(arguments).map(wrap_json),
@@ -2147,6 +2178,96 @@ fn call_test_coverage(args: Value) -> Result<Value, String> {
         },
         "groups": group_results,
         "gaps":   all_gaps,
+    }))
+}
+
+/// #247 — discover_app: kick off discovery crawler in a background thread.
+fn call_discover_app(args: Value) -> Result<Value, String> {
+    let seed_url = args.get("seed_url").and_then(Value::as_str)
+        .ok_or("seed_url required")?.to_string();
+    let max_depth = args.get("max_depth").and_then(Value::as_u64)
+        .map(|n| n as u32).unwrap_or(1);
+
+    let run_id = format!(
+        "disc_{}",
+        chrono::Utc::now().format("%Y%m%d_%H%M%S")
+    );
+    crate::test_runner::discovery::begin_run(&run_id, &seed_url, max_depth)?;
+
+    let run_id_owned = run_id.clone();
+    let seed_owned   = seed_url.clone();
+    std::thread::spawn(move || {
+        match crate::test_runner::discovery::crawl_app(
+            &seed_owned, max_depth, &run_id_owned,
+        ) {
+            Ok(count) => {
+                let _ = crate::test_runner::discovery::finish_run(
+                    &run_id_owned, "done", Some(count), None,
+                );
+            }
+            Err(e) => {
+                let _ = crate::test_runner::discovery::finish_run(
+                    &run_id_owned, "failed", Some(0), Some(&e),
+                );
+            }
+        }
+    });
+
+    Ok(json!({
+        "run_id":    run_id,
+        "seed_url":  seed_url,
+        "max_depth": max_depth,
+        "note":      "crawl spawned; poll discovery_status for progress",
+    }))
+}
+
+/// #247 — discovery_status: snapshot of latest run + counts.
+fn call_discovery_status() -> Result<Value, String> {
+    let latest = crate::test_runner::discovery::latest_run()?;
+    let total  = crate::test_runner::discovery::feature_count().unwrap_or(0);
+    match latest {
+        None => Ok(json!({
+            "status":            "not_run",
+            "total_features":    total,
+            "note":              "discovery 從未執行；用 discover_app 啟動",
+        })),
+        Some(r) => Ok(json!({
+            "status":            r.status,
+            "run_id":            r.run_id,
+            "started_at":        r.started_at,
+            "finished_at":       r.finished_at,
+            "total_widgets":     r.total_widgets,
+            "error":             r.error,
+            "seed_url":          r.seed_url,
+            "max_depth":         r.max_depth,
+            "total_features":    total,
+        })),
+    }
+}
+
+/// #247 — discovery_features: list discovered features (newest first).
+fn call_discovery_features(args: Value) -> Result<Value, String> {
+    let limit = args.get("limit").and_then(Value::as_u64).unwrap_or(100) as usize;
+    let kind_filter = args.get("kind").and_then(Value::as_str).map(String::from);
+
+    let mut feats = crate::test_runner::discovery::list_features()?;
+    if let Some(ref k) = kind_filter {
+        feats.retain(|f| f.kind == *k);
+    }
+    let total = feats.len();
+    feats.truncate(limit);
+
+    Ok(json!({
+        "total":     total,
+        "returned":  feats.len(),
+        "features":  feats.iter().map(|f| json!({
+            "route":     f.route,
+            "label":     f.label,
+            "kind":      f.kind,
+            "selector":  f.selector,
+            "last_seen": f.last_seen,
+            "run_id":    f.run_id,
+        })).collect::<Vec<_>>(),
     }))
 }
 

--- a/src/test_runner/discovery.rs
+++ b/src/test_runner/discovery.rs
@@ -188,6 +188,12 @@ pub fn crawl_app(seed_url: &str, max_depth: u32, run_id: &str) -> Result<u32, St
     // by future "wait for DOM stable" follow-up).
     std::thread::sleep(std::time::Duration::from_millis(2000));
 
+    // Always nudge Flutter into building its semantics tree — idempotent
+    // for non-Flutter sites, essential for Flutter sites where the regular
+    // DOM is just a canvas + the "Enable accessibility" placeholder.
+    let _ = crate::browser_ax::enable_flutter_semantics();
+    std::thread::sleep(std::time::Duration::from_millis(800));
+
     let snap = crate::browser::dom_snapshot(200)?;
     let url = snap["url"].as_str().unwrap_or(seed_url).to_string();
     let route = extract_route(&url);
@@ -226,6 +232,43 @@ pub fn crawl_app(seed_url: &str, max_depth: u32, run_id: &str) -> Result<u32, St
         };
         if record_feature(&feat).is_ok() {
             count += 1;
+        }
+    }
+
+    // ── Flutter shadow DOM enumeration ──────────────────────────────────
+    // After enable_flutter_semantics, flt-semantics-host populates with
+    // [role]-tagged nodes that dom_snapshot can't see (open shadow root).
+    // Walk those separately and merge into discovered features.
+    if let Ok(shadow_entries) = crate::browser::shadow_dump() {
+        for entry in shadow_entries {
+            // shadow_dump format: "role:label"
+            let (role, label) = match entry.split_once(':') {
+                Some((r, l)) => (r.trim().to_string(), l.trim().to_string()),
+                None => continue,
+            };
+            if label.is_empty() || role.starts_with("ERROR") || role.starts_with("EMPTY") {
+                continue;
+            }
+            // Map Flutter ARIA roles → discovery kinds.
+            let kind = match role.as_str() {
+                "button"                       => "button",
+                "link"                         => "link",
+                "tab" | "menuitem"             => role.as_str(),
+                "textbox" | "combobox"         => "form_input",
+                "checkbox" | "radio"           => "form_input",
+                _                              => continue, // skip generic/text
+            };
+            let feat = DiscoveredFeature {
+                route: route.clone(),
+                label,
+                kind: kind.to_string(),
+                selector: None, // shadow DOM nodes don't get data-sirin-ref
+                last_seen: now.clone(),
+                run_id: Some(run_id.to_string()),
+            };
+            if record_feature(&feat).is_ok() {
+                count += 1;
+            }
         }
     }
 

--- a/src/test_runner/discovery.rs
+++ b/src/test_runner/discovery.rs
@@ -1,0 +1,340 @@
+//! Auto-discovery crawler — Issue #247.
+//!
+//! Sirin opens the running app, walks clickable widgets / routes via CDP,
+//! and writes what it finds to SQLite. The Coverage panel diffs the
+//! discovered set against `config/coverage/agora_market.yaml` to surface:
+//!
+//!   • Discovered → real number for the funnel's tier 1
+//!   • Discovery Gaps — features Sirin saw but YAML doesn't list
+//!
+//! Iteration 1 (this commit) ships the data layer:
+//!   • Types: DiscoveredFeature, DiscoveryRun
+//!   • SQLite table schemas (in store.rs)
+//!   • Storage helpers: insert / list / latest run / clear
+//!
+//! Iteration 2 wires the actual browser crawl using BrowserService.
+
+use rusqlite::params;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiscoveredFeature {
+    pub route:     String,
+    pub label:     String,
+    /// "button" | "link" | "form_input" | "page" | "tab" | "menuitem"
+    pub kind:      String,
+    pub selector:  Option<String>,
+    pub last_seen: String,
+    pub run_id:    Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiscoveryRun {
+    pub run_id:        String,
+    pub started_at:    String,
+    pub finished_at:   Option<String>,
+    /// "running" | "done" | "failed"
+    pub status:        String,
+    pub total_widgets: Option<u32>,
+    pub error:         Option<String>,
+    pub seed_url:      Option<String>,
+    pub max_depth:     Option<u32>,
+}
+
+// ── DB access ─────────────────────────────────────────────────────────────────
+
+fn db() -> &'static std::sync::Mutex<rusqlite::Connection> {
+    // Reuse the test_runner::store DB connection (shared schema location).
+    crate::test_runner::store::__db_for_discovery()
+}
+
+/// Begin a new discovery run. Returns the row id.
+pub fn begin_run(run_id: &str, seed_url: &str, max_depth: u32) -> Result<(), String> {
+    let conn = db().lock().map_err(|e| e.to_string())?;
+    conn.execute(
+        "INSERT INTO discovery_runs (run_id, started_at, status, seed_url, max_depth) \
+         VALUES (?1, ?2, 'running', ?3, ?4)",
+        params![run_id, now_rfc3339(), seed_url, max_depth as i64],
+    ).map_err(|e| format!("insert discovery_run: {e}"))?;
+    Ok(())
+}
+
+/// Mark a run finished — status either "done" or "failed".
+pub fn finish_run(
+    run_id:        &str,
+    status:        &str,
+    total_widgets: Option<u32>,
+    error:         Option<&str>,
+) -> Result<(), String> {
+    let conn = db().lock().map_err(|e| e.to_string())?;
+    conn.execute(
+        "UPDATE discovery_runs \
+         SET finished_at = ?1, status = ?2, total_widgets = ?3, error = ?4 \
+         WHERE run_id = ?5",
+        params![now_rfc3339(), status, total_widgets.map(|n| n as i64), error, run_id],
+    ).map_err(|e| format!("update discovery_run: {e}"))?;
+    Ok(())
+}
+
+/// Insert (or update last_seen on) a discovered feature.
+/// Dedups on (route, label, kind).
+pub fn record_feature(feat: &DiscoveredFeature) -> Result<(), String> {
+    let conn = db().lock().map_err(|e| e.to_string())?;
+    conn.execute(
+        "INSERT INTO discovered_features (route, label, kind, selector, last_seen, run_id) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+         ON CONFLICT(route, label, kind) DO UPDATE SET \
+            last_seen = excluded.last_seen, \
+            run_id    = excluded.run_id, \
+            selector  = COALESCE(excluded.selector, selector)",
+        params![
+            feat.route, feat.label, feat.kind,
+            feat.selector, feat.last_seen, feat.run_id,
+        ],
+    ).map_err(|e| format!("upsert feature: {e}"))?;
+    Ok(())
+}
+
+/// List all discovered features (newest last_seen first).
+pub fn list_features() -> Result<Vec<DiscoveredFeature>, String> {
+    let conn = db().lock().map_err(|e| e.to_string())?;
+    let mut stmt = conn.prepare(
+        "SELECT route, label, kind, selector, last_seen, run_id \
+         FROM discovered_features \
+         ORDER BY last_seen DESC",
+    ).map_err(|e| format!("prepare list_features: {e}"))?;
+    let rows = stmt.query_map([], |r| {
+        Ok(DiscoveredFeature {
+            route:     r.get(0)?,
+            label:     r.get(1)?,
+            kind:      r.get(2)?,
+            selector:  r.get(3)?,
+            last_seen: r.get(4)?,
+            run_id:    r.get(5)?,
+        })
+    }).map_err(|e| format!("query list_features: {e}"))?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(|e| e.to_string())
+}
+
+/// Total distinct features ever discovered.
+pub fn feature_count() -> Result<u32, String> {
+    let conn = db().lock().map_err(|e| e.to_string())?;
+    let n: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM discovered_features", [], |r| r.get(0),
+    ).map_err(|e| format!("count features: {e}"))?;
+    Ok(n.max(0) as u32)
+}
+
+/// Latest discovery run (any status), or None when none exist yet.
+pub fn latest_run() -> Result<Option<DiscoveryRun>, String> {
+    let conn = db().lock().map_err(|e| e.to_string())?;
+    let mut stmt = conn.prepare(
+        "SELECT run_id, started_at, finished_at, status, total_widgets, \
+                error, seed_url, max_depth \
+         FROM discovery_runs \
+         ORDER BY started_at DESC LIMIT 1",
+    ).map_err(|e| format!("prepare latest_run: {e}"))?;
+    let mut rows = stmt.query([]).map_err(|e| e.to_string())?;
+    if let Some(r) = rows.next().map_err(|e| e.to_string())? {
+        Ok(Some(DiscoveryRun {
+            run_id:        r.get(0).map_err(|e| e.to_string())?,
+            started_at:    r.get(1).map_err(|e| e.to_string())?,
+            finished_at:   r.get(2).map_err(|e| e.to_string())?,
+            status:        r.get(3).map_err(|e| e.to_string())?,
+            total_widgets: r.get::<_, Option<i64>>(4)
+                .map_err(|e| e.to_string())?
+                .map(|n| n.max(0) as u32),
+            error:         r.get(5).map_err(|e| e.to_string())?,
+            seed_url:      r.get(6).map_err(|e| e.to_string())?,
+            max_depth:     r.get::<_, Option<i64>>(7)
+                .map_err(|e| e.to_string())?
+                .map(|n| n.max(0) as u32),
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Wipe all discovered features and run history. Used for "fresh crawl"
+/// resets and tests.
+#[allow(dead_code)]
+pub fn clear_all() -> Result<(), String> {
+    let conn = db().lock().map_err(|e| e.to_string())?;
+    conn.execute_batch(
+        "DELETE FROM discovered_features; DELETE FROM discovery_runs;",
+    ).map_err(|e| format!("clear: {e}"))?;
+    Ok(())
+}
+
+// ── Crawler (iter 2) ──────────────────────────────────────────────────────────
+
+/// Crawl the running app starting at `seed_url`, enumerate interactable
+/// elements via Sirin's `dom_snapshot`, and persist each as a
+/// `DiscoveredFeature`. Depth-1 only in iter 2 — recursion (click into
+/// each widget, walk the resulting page, back up) is left for later.
+///
+/// Returns the number of features recorded (after dedup).
+///
+/// Caller is expected to wrap this in a thread; it blocks on browser I/O.
+pub fn crawl_app(seed_url: &str, max_depth: u32, run_id: &str) -> Result<u32, String> {
+    // Ensure Chrome is up.  `false` = headed so the user can watch; the
+    // launch_discovery wrapper can override if it wants headless.
+    let _ = crate::browser::ensure_open(false)?;
+    crate::browser::navigate(seed_url)?;
+
+    // Brief settle window — DOM is usually ready in 1-2s for SPAs;
+    // hash-route apps with async splash screens may need longer (handled
+    // by future "wait for DOM stable" follow-up).
+    std::thread::sleep(std::time::Duration::from_millis(2000));
+
+    let snap = crate::browser::dom_snapshot(200)?;
+    let url = snap["url"].as_str().unwrap_or(seed_url).to_string();
+    let route = extract_route(&url);
+
+    let elements = snap["elements"].as_array().cloned().unwrap_or_default();
+    let now = now_rfc3339();
+    let mut count = 0u32;
+
+    for el in elements {
+        let name = el["name"].as_str().unwrap_or("").trim().to_string();
+        if name.is_empty() { continue; }
+        let role = el["role"].as_str().unwrap_or("generic");
+        let tag  = el["tag"].as_str().unwrap_or("");
+        let href = el["href"].as_str().map(String::from);
+        let ref_id = el["ref"].as_str()
+            .map(|s| format!("[data-sirin-ref=\"{s}\"]"));
+
+        let kind = role_to_kind(role, tag);
+        if kind == "generic" { continue; }
+
+        // For links, the *destination* is the more useful "route" — it
+        // tells us a future page exists. For everything else, current route.
+        let route_for_feat = if kind == "link" {
+            href.clone().unwrap_or_else(|| route.clone())
+        } else {
+            route.clone()
+        };
+
+        let feat = DiscoveredFeature {
+            route: route_for_feat,
+            label: name,
+            kind: kind.to_string(),
+            selector: ref_id,
+            last_seen: now.clone(),
+            run_id: Some(run_id.to_string()),
+        };
+        if record_feature(&feat).is_ok() {
+            count += 1;
+        }
+    }
+
+    // TODO(#247 follow-up): depth > 1 means click each kind=button, snapshot
+    // again, then back. Needs visited-route tracking + state restore.
+    let _ = max_depth;
+
+    Ok(count)
+}
+
+fn extract_route(url: &str) -> String {
+    // Flutter hash routes: http://app.com/#/buyer/checkout → "#/buyer/checkout"
+    if let Some(idx) = url.find("#/") {
+        return url[idx..].to_string();
+    }
+    // Standard path: http://app.com/foo/bar → "/foo/bar"
+    if let Some(scheme_end) = url.find("://") {
+        let after_scheme = &url[scheme_end + 3..];
+        if let Some(slash) = after_scheme.find('/') {
+            return after_scheme[slash..].to_string();
+        }
+        return "/".to_string();
+    }
+    url.to_string()
+}
+
+fn role_to_kind(role: &str, tag: &str) -> &'static str {
+    match role {
+        "button"                       => "button",
+        "link"                         => "link",
+        "textbox" | "combobox"         => "form_input",
+        "tab"                          => "tab",
+        "menuitem"                     => "menuitem",
+        "checkbox" | "radio"           => "form_input",
+        _ => match tag {
+            "a"      => "link",
+            "button" => "button",
+            "input" | "select" | "textarea" => "form_input",
+            _        => "generic",
+        },
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh() {
+        let _ = clear_all();
+    }
+
+    #[test]
+    fn record_and_list() {
+        fresh();
+        let f = DiscoveredFeature {
+            route:     "/buyer/checkout".into(),
+            label:     "Place Order".into(),
+            kind:      "button".into(),
+            selector:  Some("[data-test='place-order']".into()),
+            last_seen: now_rfc3339(),
+            run_id:    Some("disc_test_1".into()),
+        };
+        record_feature(&f).expect("record");
+        let all = list_features().expect("list");
+        assert!(all.iter().any(|g| g.label == "Place Order"));
+    }
+
+    #[test]
+    fn upsert_dedups_by_route_label_kind() {
+        fresh();
+        let f = DiscoveredFeature {
+            route:     "/seller/products".into(),
+            label:     "Add Product".into(),
+            kind:      "button".into(),
+            selector:  None,
+            last_seen: now_rfc3339(),
+            run_id:    Some("disc_a".into()),
+        };
+        record_feature(&f).expect("first");
+        let mut g = f.clone();
+        g.run_id = Some("disc_b".into());
+        g.selector = Some(".btn-add".into());
+        record_feature(&g).expect("second");
+        let all = list_features().expect("list");
+        let matches: Vec<_> = all.iter()
+            .filter(|x| x.route == "/seller/products" && x.label == "Add Product")
+            .collect();
+        assert_eq!(matches.len(), 1, "should dedup on (route,label,kind)");
+        assert_eq!(matches[0].run_id.as_deref(), Some("disc_b"));
+        assert_eq!(matches[0].selector.as_deref(), Some(".btn-add"));
+    }
+
+    #[test]
+    fn run_lifecycle() {
+        fresh();
+        begin_run("disc_lifecycle_1", "http://localhost:3000", 3).expect("begin");
+        let latest = latest_run().expect("latest").expect("some");
+        assert_eq!(latest.status, "running");
+        finish_run("disc_lifecycle_1", "done", Some(42), None).expect("finish");
+        let latest = latest_run().expect("latest").expect("some");
+        assert_eq!(latest.status, "done");
+        assert_eq!(latest.total_widgets, Some(42));
+    }
+}

--- a/src/test_runner/mod.rs
+++ b/src/test_runner/mod.rs
@@ -23,6 +23,7 @@ pub mod ax_diff_context;
 pub mod som_renderer;
 pub mod action_verify;
 pub mod gif_recorder;
+pub mod discovery;
 
 pub use parser::{TestGoal, Fixture};
 pub use executor::{TestResult, TestStatus};

--- a/src/test_runner/store.rs
+++ b/src/test_runner/store.rs
@@ -16,6 +16,13 @@ fn db_path() -> PathBuf {
     crate::platform::app_data_dir().join("memory").join("test_memory.db")
 }
 
+/// Shared DB accessor for the discovery module — Issue #247 keeps its
+/// `discovered_features` / `discovery_runs` tables in the same SQLite file
+/// so the schema migrations and OnceLock init stay centralized here.
+pub(crate) fn __db_for_discovery() -> &'static Mutex<rusqlite::Connection> {
+    db()
+}
+
 fn db() -> &'static Mutex<rusqlite::Connection> {
     static DB: OnceLock<Mutex<rusqlite::Connection>> = OnceLock::new();
     DB.get_or_init(|| {
@@ -124,6 +131,39 @@ fn db() -> &'static Mutex<rusqlite::Connection> {
         let _ = conn.execute(
             "ALTER TABLE test_runs ADD COLUMN console_log TEXT",
             [],
+        );
+
+        // Issue #247 — discovery crawler tables.
+        // `discovery_runs` tracks each crawl invocation.
+        // `discovered_features` is a feature inventory the crawler builds —
+        // each row = one (route, label, kind) it observed.
+        // The diff against `coverage/agora_market.yaml` produces the
+        // 3-tier funnel's "Discovered" count + "Discovery Gaps" list.
+        let _ = conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS discovery_runs ( \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                run_id TEXT NOT NULL UNIQUE, \
+                started_at TEXT NOT NULL, \
+                finished_at TEXT, \
+                status TEXT NOT NULL, \
+                total_widgets INTEGER, \
+                error TEXT, \
+                seed_url TEXT, \
+                max_depth INTEGER \
+            ); \
+            CREATE INDEX IF NOT EXISTS idx_disc_run_started ON discovery_runs(started_at DESC); \
+            CREATE TABLE IF NOT EXISTS discovered_features ( \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                route TEXT NOT NULL, \
+                label TEXT NOT NULL, \
+                kind TEXT NOT NULL, \
+                selector TEXT, \
+                last_seen TEXT NOT NULL, \
+                run_id TEXT, \
+                UNIQUE(route, label, kind) \
+            ); \
+            CREATE INDEX IF NOT EXISTS idx_disc_feat_route ON discovered_features(route); \
+            CREATE INDEX IF NOT EXISTS idx_disc_feat_run ON discovered_features(run_id);",
         );
 
         Mutex::new(conn)

--- a/src/ui_egui/command_palette.rs
+++ b/src/ui_egui/command_palette.rs
@@ -1,0 +1,262 @@
+//! ⌘K Command Palette — overlay for accessing secondary features that the
+//! sidebar and top-bar don't surface directly.
+//!
+//! Triggered by Ctrl+K / Cmd+K (handled in mod.rs) or by clicking the ⌘K hint
+//! in the top bar. Press Esc to close. Arrow keys navigate, Enter selects.
+
+use eframe::egui::{self, RichText};
+use super::theme;
+
+/// One entry in the palette. The action is interpreted by the parent app.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum PaletteEntry {
+    // Testing-tab targets (handled by switching View + setting tab)
+    Coverage,
+    Browser,
+    // Modal targets — automation_panel sub-tabs
+    DevSquad,
+    McpPlayground,
+    // Modal targets — ops_panel sub-tabs
+    AiRouter,
+    SessionTasks,
+    CostKb,
+    // Modal targets — system_panel sub-tabs
+    Settings,
+    Logs,
+    // Quick action — focus the dashboard
+    GoDashboard,
+}
+
+impl PaletteEntry {
+    pub const ALL: &'static [Self] = &[
+        Self::Coverage, Self::Browser, Self::DevSquad, Self::McpPlayground,
+        Self::AiRouter, Self::SessionTasks, Self::CostKb,
+        Self::Settings, Self::Logs, Self::GoDashboard,
+    ];
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Coverage      => "Coverage Map",
+            Self::Browser       => "Browser Monitor",
+            Self::DevSquad      => "Dev Squad",
+            Self::McpPlayground => "MCP Playground",
+            Self::AiRouter      => "AI Router",
+            Self::SessionTasks  => "Session & Tasks",
+            Self::CostKb        => "Cost & KB Stats",
+            Self::Settings      => "Settings",
+            Self::Logs          => "System Logs",
+            Self::GoDashboard   => "Go to Dashboard",
+        }
+    }
+
+    pub fn group(&self) -> &'static str {
+        match self {
+            Self::Coverage | Self::Browser => "TESTING",
+            Self::DevSquad | Self::McpPlayground => "AUTOMATION",
+            Self::AiRouter | Self::SessionTasks | Self::CostKb => "OPS",
+            Self::Settings | Self::Logs => "SYSTEM",
+            Self::GoDashboard => "VIEW",
+        }
+    }
+
+    pub fn keywords(&self) -> &'static str {
+        match self {
+            Self::Coverage      => "test feature map gap script",
+            Self::Browser       => "chrome cdp screenshot viewport",
+            Self::DevSquad      => "team pm engineer tester github queue",
+            Self::McpPlayground => "tools external mcp",
+            Self::AiRouter      => "llm route benchmark intent gemini deepseek",
+            Self::SessionTasks  => "task save point todo",
+            Self::CostKb        => "cost token spend kb knowledge base",
+            Self::Settings      => "config persona llm api key telegram",
+            Self::Logs          => "log error warn",
+            Self::GoDashboard   => "home main",
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct PaletteState {
+    pub open:   bool,
+    pub query:  String,
+    pub idx:    usize,
+}
+
+impl PaletteState {
+    pub fn open(&mut self) {
+        self.open = true;
+        self.query.clear();
+        self.idx = 0;
+    }
+    pub fn close(&mut self) {
+        self.open = false;
+        self.query.clear();
+        self.idx = 0;
+    }
+}
+
+/// Render the palette if open. Returns `Some(entry)` when the user selects.
+/// The parent should react and then close the palette via `state.close()`.
+pub fn show(ctx: &egui::Context, state: &mut PaletteState) -> Option<PaletteEntry> {
+    if !state.open { return None; }
+
+    // ESC closes.
+    if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
+        state.close();
+        return None;
+    }
+
+    // Filter entries by query.
+    let q = state.query.to_lowercase();
+    let filtered: Vec<PaletteEntry> = PaletteEntry::ALL.iter().copied()
+        .filter(|e| {
+            q.is_empty()
+                || e.label().to_lowercase().contains(&q)
+                || e.keywords().to_lowercase().contains(&q)
+                || e.group().to_lowercase().contains(&q)
+        })
+        .collect();
+
+    // Clamp index.
+    if filtered.is_empty() {
+        state.idx = 0;
+    } else if state.idx >= filtered.len() {
+        state.idx = filtered.len() - 1;
+    }
+
+    // Arrow keys + Enter.
+    let nav_up    = ctx.input(|i| i.key_pressed(egui::Key::ArrowUp));
+    let nav_down  = ctx.input(|i| i.key_pressed(egui::Key::ArrowDown));
+    let confirm   = ctx.input(|i| i.key_pressed(egui::Key::Enter));
+    if nav_down && !filtered.is_empty() {
+        state.idx = (state.idx + 1) % filtered.len();
+    }
+    if nav_up && !filtered.is_empty() {
+        state.idx = if state.idx == 0 { filtered.len() - 1 } else { state.idx - 1 };
+    }
+
+    let mut chosen: Option<PaletteEntry> = None;
+    if confirm {
+        chosen = filtered.get(state.idx).copied();
+    }
+
+    // ── Backdrop (dimmed full-screen click-catcher) ────────────────────
+    let screen = ctx.screen_rect();
+    egui::Area::new(egui::Id::new("palette_backdrop"))
+        .fixed_pos(screen.min)
+        .order(egui::Order::Background)
+        .show(ctx, |ui| {
+            let resp = ui.allocate_response(screen.size(), egui::Sense::click());
+            ui.painter().rect_filled(screen, 0.0,
+                egui::Color32::from_rgba_unmultiplied(0, 0, 0, 140));
+            if resp.clicked() { /* close handled below */ }
+        });
+    // Click outside the popup → close.
+    if ctx.input(|i| i.pointer.any_click())
+        && !ctx.is_pointer_over_area()
+    {
+        // No-op: the popup `Area` will register hover; the backdrop catches outside clicks.
+    }
+
+    // ── Popup ──────────────────────────────────────────────────────────
+    egui::Area::new(egui::Id::new("palette_popup"))
+        .anchor(egui::Align2::CENTER_TOP, egui::vec2(0.0, 80.0))
+        .order(egui::Order::Foreground)
+        .show(ctx, |ui| {
+            egui::Frame::popup(ui.style())
+                .fill(theme::CARD)
+                .corner_radius(6.0)
+                .inner_margin(theme::SP_MD)
+                .stroke(egui::Stroke::new(1.0, theme::BORDER))
+                .show(ui, |ui| {
+                    ui.set_width(440.0);
+
+                    // Header
+                    ui.horizontal(|ui| {
+                        ui.colored_label(theme::TEXT_DIM,
+                            RichText::new("⌘K").size(theme::FONT_CAPTION).monospace());
+                        ui.colored_label(theme::TEXT_DIM,
+                            RichText::new("Command Palette").size(theme::FONT_SMALL));
+                        ui.with_layout(
+                            egui::Layout::right_to_left(egui::Align::Center),
+                            |ui| {
+                                ui.colored_label(theme::TEXT_DIM,
+                                    RichText::new("Esc").size(theme::FONT_CAPTION).monospace());
+                            },
+                        );
+                    });
+                    ui.add_space(theme::SP_XS);
+
+                    // Search input — auto-focus
+                    let resp = ui.add(
+                        egui::TextEdit::singleline(&mut state.query)
+                            .desired_width(f32::INFINITY)
+                            .hint_text("Type to filter…")
+                            .font(egui::TextStyle::Body),
+                    );
+                    if !resp.has_focus() {
+                        resp.request_focus();
+                    }
+                    ui.add_space(theme::SP_SM);
+                    theme::thin_separator(ui);
+                    ui.add_space(theme::SP_XS);
+
+                    if filtered.is_empty() {
+                        ui.colored_label(theme::TEXT_DIM,
+                            RichText::new("No matches").size(theme::FONT_CAPTION));
+                        return;
+                    }
+
+                    // Entries
+                    egui::ScrollArea::vertical()
+                        .id_salt("palette_list")
+                        .max_height(360.0)
+                        .show(ui, |ui| {
+                            for (i, entry) in filtered.iter().enumerate() {
+                                if entry_row(ui, *entry, i == state.idx).clicked() {
+                                    chosen = Some(*entry);
+                                }
+                            }
+                        });
+                });
+        });
+
+    chosen
+}
+
+fn entry_row(ui: &mut egui::Ui, entry: PaletteEntry, active: bool) -> egui::Response {
+    let (rect, resp) = ui.allocate_exact_size(
+        egui::vec2(ui.available_width(), 28.0),
+        egui::Sense::click(),
+    );
+    if active || resp.hovered() {
+        ui.painter().rect_filled(rect, 4.0,
+            if active { theme::HOVER } else { theme::BG.linear_multiply(0.5) });
+    }
+    if active {
+        let bar = egui::Rect::from_min_size(
+            rect.left_top(), egui::vec2(3.0, rect.height()),
+        );
+        ui.painter().rect_filled(bar, 1.0, theme::ACCENT);
+    }
+
+    let text_color = if active { theme::TEXT } else { theme::TEXT_DIM };
+    // Group tag (left, fixed width)
+    ui.painter().text(
+        egui::pos2(rect.left() + theme::SP_MD, rect.center().y),
+        egui::Align2::LEFT_CENTER,
+        entry.group(),
+        egui::FontId::monospace(theme::FONT_CAPTION),
+        theme::TEXT_DIM,
+    );
+    // Label
+    ui.painter().text(
+        egui::pos2(rect.left() + 110.0, rect.center().y),
+        egui::Align2::LEFT_CENTER,
+        entry.label(),
+        egui::FontId::proportional(theme::FONT_BODY),
+        text_color,
+    );
+
+    resp.on_hover_cursor(egui::CursorIcon::PointingHand)
+}

--- a/src/ui_egui/coverage_panel.rs
+++ b/src/ui_egui/coverage_panel.rs
@@ -1,13 +1,23 @@
-//! Coverage Panel — standalone view (previously sub-tab of test_dashboard).
-//! Shows the feature map from config/coverage/agora_market.yaml with
-//! per-group progress bars and a missing-feature gap list.
+//! Coverage Panel — full-page 3-tier funnel + per-group + per-feature detail.
+//!
+//! Tiers (top to bottom in the funnel):
+//!   1. Discovered — features Sirin's auto-crawler found (mock until real
+//!                   discovery module ships)
+//!   2. Covered    — features with at least one YAML test_id
+//!   3. Scripted   — covered features whose tests are deterministic replay
+//!                   scripts (no longer need LLM decisions)
+//!
+//! Per-feature glyphs:
+//!   ⚡ = scripted (status: confirmed) — deterministic, fastest
+//!   🤖 = LLM-only (status: partial)   — still requires LLM each run
+//!   ○ = missing                      — no test at all
 
 use std::sync::Arc;
 use eframe::egui::{self, RichText, ScrollArea};
-use crate::ui_service::{AppService, CoverageData};
+use crate::ui_service::{AppService, CoverageData, DiscoveryStatus};
 use super::theme;
 
-// ── State ──────────────────────────────────────────────────────��─────────────
+// ── State ────────────────────────────────────────────────────────────────────
 
 pub struct CoveragePanelState {
     data:    Option<Result<CoverageData, String>>,
@@ -27,7 +37,6 @@ impl Default for CoveragePanelState {
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 pub fn show(ui: &mut egui::Ui, svc: &Arc<dyn AppService>, state: &mut CoveragePanelState) {
-    // Refresh every 30 s or on first load.
     if state.data.is_none()
         || state.refresh.elapsed() > std::time::Duration::from_secs(30)
     {
@@ -35,21 +44,12 @@ pub fn show(ui: &mut egui::Ui, svc: &Arc<dyn AppService>, state: &mut CoveragePa
         state.refresh = std::time::Instant::now();
     }
 
-    // Header row with refresh button.
+    // ── Header ───────────────────────────────────────────────────────────
     ui.horizontal(|ui| {
-        ui.colored_label(theme::TEXT, RichText::new("COVERAGE").size(theme::FONT_TITLE).strong());
-        ui.add_space(theme::SP_SM);
-        if let Some(Ok(data)) = &state.data {
-            let pct = if data.total_features > 0 {
-                data.total_covered as f32 / data.total_features as f32
-            } else { 0.0 };
-            let col = coverage_color(pct);
-            ui.colored_label(col,
-                RichText::new(format!("{}/{} ({:.0}%)",
-                    data.total_covered, data.total_features, pct * 100.0))
-                    .size(theme::FONT_SMALL).strong().monospace(),
-            );
-        }
+        ui.colored_label(
+            theme::TEXT,
+            RichText::new("COVERAGE").size(theme::FONT_TITLE).strong(),
+        );
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
             if ui.add(egui::Button::new(
                 RichText::new("↻ Refresh").size(theme::FONT_CAPTION).color(theme::TEXT_DIM)
@@ -71,43 +71,125 @@ pub fn show(ui: &mut egui::Ui, svc: &Arc<dyn AppService>, state: &mut CoveragePa
                 });
             }
             Some(Err(e)) => {
-                ui.colored_label(theme::DANGER,
-                    RichText::new(format!("⚠ {e}")).size(theme::FONT_SMALL));
+                ui.colored_label(
+                    theme::DANGER,
+                    RichText::new(format!("⚠ {e}")).size(theme::FONT_SMALL),
+                );
             }
             Some(Ok(data)) => {
-                show_coverage_data(ui, data);
+                show_funnel(ui, data);
+                ui.add_space(theme::SP_LG);
+                show_groups(ui, data);
+                show_gaps(ui, data);
             }
         }
     });
 }
 
-// ── Internal renderers ────────────────────────────────────────────────────────
+// ── 3-tier funnel (top of page) ──────────────────────────────────────────────
 
-fn show_coverage_data(ui: &mut egui::Ui, data: &CoverageData) {
-    let pct = if data.total_features > 0 {
-        data.total_covered as f32 / data.total_features as f32
-    } else { 0.0 };
+fn show_funnel(ui: &mut egui::Ui, d: &CoverageData) {
+    let total = d.discovered.max(1);
+    let cov_pct = d.total_covered as f32 / total as f32;
+    let scr_pct = d.scripted as f32 / total as f32;
+    let bar_w = 300.0;
 
-    // Overall bar.
+    egui::Frame::new()
+        .fill(theme::CARD)
+        .corner_radius(4.0)
+        .inner_margin(theme::SP_MD)
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.colored_label(
+                    theme::TEXT,
+                    RichText::new(&d.product).size(theme::FONT_BODY).strong(),
+                );
+                ui.colored_label(
+                    theme::TEXT_DIM,
+                    RichText::new(format!("v{}", d.version))
+                        .size(theme::FONT_CAPTION).monospace(),
+                );
+            });
+            ui.add_space(theme::SP_SM);
+
+            funnel_row(ui, "探索 Discovered",
+                d.discovered, total, 1.0, theme::TEXT_DIM, bar_w);
+            if matches!(d.discovery_status, DiscoveryStatus::NotRun) {
+                ui.horizontal(|ui| {
+                    ui.add_space(160.0);
+                    ui.colored_label(
+                        theme::TEXT_DIM,
+                        RichText::new("(mock — discovery 模組待實作；功能規劃中)")
+                            .size(theme::FONT_CAPTION).italics(),
+                    );
+                });
+            }
+            funnel_row(ui, "覆蓋 Covered",
+                d.total_covered, total, cov_pct, theme::ACCENT, bar_w);
+            funnel_row(ui, "有腳本 Scripted",
+                d.scripted, total, scr_pct, theme::INFO, bar_w);
+
+            ui.add_space(theme::SP_SM);
+            ui.horizontal(|ui| {
+                ui.add_space(160.0);
+                ui.colored_label(
+                    theme::TEXT_DIM,
+                    RichText::new("⚡ scripted   🤖 LLM-only   ○ missing")
+                        .size(theme::FONT_CAPTION).monospace(),
+                );
+            });
+        });
+}
+
+fn funnel_row(
+    ui:    &mut egui::Ui,
+    label: &str,
+    n:     usize,
+    _max:  usize,
+    pct:   f32,
+    color: egui::Color32,
+    bar_w: f32,
+) {
     ui.horizontal(|ui| {
-        ui.colored_label(theme::TEXT_DIM,
-            RichText::new(format!("{} v{}", data.product, data.version))
-                .size(theme::FONT_CAPTION).monospace());
-        ui.add_space(theme::SP_MD);
-        let bar_w = 160.0;
-        let bar_h = 8.0;
-        let (rect, _) = ui.allocate_exact_size(egui::vec2(bar_w, bar_h), egui::Sense::hover());
+        ui.allocate_ui_with_layout(
+            egui::vec2(160.0, 18.0),
+            egui::Layout::left_to_right(egui::Align::Center),
+            |ui| {
+                ui.colored_label(theme::TEXT,
+                    RichText::new(label).size(theme::FONT_SMALL));
+            },
+        );
+        ui.allocate_ui_with_layout(
+            egui::vec2(40.0, 18.0),
+            egui::Layout::right_to_left(egui::Align::Center),
+            |ui| {
+                ui.colored_label(theme::TEXT,
+                    RichText::new(format!("{n}"))
+                        .size(theme::FONT_SMALL).monospace().strong());
+            },
+        );
+        ui.add_space(theme::SP_SM);
+        let (rect, _) = ui.allocate_exact_size(
+            egui::vec2(bar_w, 8.0), egui::Sense::hover());
         let p = ui.painter_at(rect);
-        p.rect_filled(rect, 3.0, theme::BORDER);
-        let fill_w = (rect.width() * pct).max(0.0);
-        p.rect_filled(egui::Rect::from_min_size(rect.min, egui::vec2(fill_w, bar_h)),
-            3.0, coverage_color(pct));
+        p.rect_filled(rect, 2.0, theme::BORDER);
+        let fw = (rect.width() * pct.clamp(0.0, 1.0)).max(0.0);
+        p.rect_filled(
+            egui::Rect::from_min_size(rect.min, egui::vec2(fw, 8.0)),
+            2.0, color,
+        );
+        ui.add_space(theme::SP_SM);
+        ui.colored_label(theme::TEXT_DIM,
+            RichText::new(format!("{:.0}%", pct * 100.0))
+                .size(theme::FONT_CAPTION).monospace());
     });
-    ui.add_space(theme::SP_MD);
+    ui.add_space(theme::SP_XS);
+}
 
-    let mut gaps: Vec<(&str, &str, &str)> = Vec::new();
+// ── Per-group cards ──────────────────────────────────────────────────────────
 
-    for group in &data.groups {
+fn show_groups(ui: &mut egui::Ui, d: &CoverageData) {
+    for group in &d.groups {
         let gpct = if group.total > 0 {
             group.covered as f32 / group.total as f32
         } else { 0.0 };
@@ -121,76 +203,116 @@ fn show_coverage_data(ui: &mut egui::Ui, data: &CoverageData) {
                 ui.horizontal(|ui| {
                     ui.colored_label(gcol, RichText::new("●").size(9.0));
                     ui.colored_label(theme::TEXT,
-                        RichText::new(&group.name).size(theme::FONT_SMALL).strong());
+                        RichText::new(&group.name)
+                            .size(theme::FONT_SMALL).strong());
                     if !group.role.is_empty() {
                         ui.colored_label(theme::TEXT_DIM,
                             RichText::new(format!("[{}]", group.role))
                                 .size(theme::FONT_CAPTION).monospace());
                     }
-                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        ui.colored_label(gcol,
-                            RichText::new(format!("{}/{}", group.covered, group.total))
-                                .size(theme::FONT_CAPTION).monospace());
-                        let bw = 60.0; let bh = 6.0;
-                        let (r, _) = ui.allocate_exact_size(egui::vec2(bw, bh), egui::Sense::hover());
-                        let p = ui.painter_at(r);
-                        p.rect_filled(r, 2.0, theme::BORDER);
-                        let fw = (r.width() * gpct).max(0.0);
-                        p.rect_filled(egui::Rect::from_min_size(r.min, egui::vec2(fw, bh)), 2.0, gcol);
-                    });
+                    ui.with_layout(
+                        egui::Layout::right_to_left(egui::Align::Center),
+                        |ui| {
+                            ui.colored_label(gcol,
+                                RichText::new(format!("{}/{}", group.covered, group.total))
+                                    .size(theme::FONT_CAPTION).monospace());
+                            let bw = 60.0; let bh = 6.0;
+                            let (r, _) = ui.allocate_exact_size(
+                                egui::vec2(bw, bh), egui::Sense::hover());
+                            let p = ui.painter_at(r);
+                            p.rect_filled(r, 2.0, theme::BORDER);
+                            let fw = (r.width() * gpct).max(0.0);
+                            p.rect_filled(egui::Rect::from_min_size(
+                                r.min, egui::vec2(fw, bh)), 2.0, gcol);
+                        },
+                    );
                 });
                 ui.add_space(theme::SP_XS);
                 for feat in &group.features {
-                    let (dot, col) = match feat.status.as_str() {
-                        "confirmed" => ("✓", theme::ACCENT),
-                        "partial"   => ("◐", theme::YELLOW),
-                        _           => ("○", theme::DANGER),
+                    let (glyph, col) = match feat.status.as_str() {
+                        "confirmed" => ("⚡", theme::INFO),
+                        "partial"   => ("🤖", theme::YELLOW),
+                        _           => ("○",  theme::DANGER),
                     };
                     ui.horizontal(|ui| {
                         ui.add_space(theme::SP_MD);
-                        ui.colored_label(col, RichText::new(dot).size(theme::FONT_CAPTION));
+                        ui.colored_label(col,
+                            RichText::new(glyph).size(theme::FONT_BODY));
                         ui.colored_label(
                             if feat.status == "missing" { theme::TEXT_DIM } else { theme::TEXT },
-                            RichText::new(&feat.name).size(theme::FONT_CAPTION));
+                            RichText::new(&feat.name).size(theme::FONT_CAPTION),
+                        );
                         if !feat.test_ids.is_empty() {
                             ui.colored_label(theme::TEXT_DIM,
                                 RichText::new(format!("← {}", feat.test_ids.join(", ")))
                                     .size(theme::FONT_CAPTION).monospace());
                         }
                     });
-                    if feat.status == "missing" {
-                        gaps.push((&group.name, &feat.id, &feat.name));
-                    }
                 }
             });
         ui.add_space(theme::SP_XS);
     }
+}
 
-    if !gaps.is_empty() {
-        ui.add_space(theme::SP_SM);
-        theme::thin_separator(ui);
-        ui.add_space(theme::SP_SM);
-        ui.colored_label(theme::DANGER,
-            RichText::new(format!("GAPS  {} missing", gaps.len()))
-                .size(theme::FONT_SMALL).strong());
-        ui.add_space(theme::SP_XS);
-        for (gname, fid, fname) in &gaps {
-            ui.horizontal(|ui| {
-                ui.add_space(theme::SP_SM);
-                ui.colored_label(theme::DANGER, RichText::new("○").size(theme::FONT_CAPTION));
-                ui.colored_label(theme::TEXT_DIM,
-                    RichText::new(*fname).size(theme::FONT_CAPTION));
-                ui.colored_label(theme::TEXT_DIM,
-                    RichText::new(format!("— {gname}")).size(theme::FONT_CAPTION));
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+// ── Bottom GAPS list ─────────────────────────────────────────────────────────
+
+fn show_gaps(ui: &mut egui::Ui, d: &CoverageData) {
+    let mut coverage_gaps: Vec<(&str, &str, &str)> = Vec::new();
+    for group in &d.groups {
+        for feat in &group.features {
+            if feat.status == "missing" {
+                coverage_gaps.push((&group.name, &feat.id, &feat.name));
+            }
+        }
+    }
+
+    if coverage_gaps.is_empty() {
+        return;
+    }
+
+    ui.add_space(theme::SP_SM);
+    theme::thin_separator(ui);
+    ui.add_space(theme::SP_SM);
+
+    ui.colored_label(theme::DANGER,
+        RichText::new(format!("COVERAGE GAPS  {} missing", coverage_gaps.len()))
+            .size(theme::FONT_SMALL).strong());
+    ui.add_space(theme::SP_XS);
+    for (gname, fid, fname) in &coverage_gaps {
+        ui.horizontal(|ui| {
+            ui.add_space(theme::SP_SM);
+            ui.colored_label(theme::DANGER,
+                RichText::new("○").size(theme::FONT_CAPTION));
+            ui.colored_label(theme::TEXT_DIM,
+                RichText::new(*fname).size(theme::FONT_CAPTION));
+            ui.colored_label(theme::TEXT_DIM,
+                RichText::new(format!("— {gname}")).size(theme::FONT_CAPTION));
+            ui.with_layout(
+                egui::Layout::right_to_left(egui::Align::Center),
+                |ui| {
                     ui.colored_label(theme::INFO,
                         RichText::new(format!("agora_{fid}"))
                             .size(theme::FONT_CAPTION).monospace())
                         .on_hover_text("suggested YAML test name");
-                });
-            });
-        }
+                },
+            );
+        });
     }
+
+    // Discovery gaps (mock — empty until real crawler ships).
+    ui.add_space(theme::SP_SM);
+    theme::thin_separator(ui);
+    ui.add_space(theme::SP_SM);
+    ui.colored_label(theme::TEXT_DIM,
+        RichText::new("DISCOVERY GAPS  0 (discovery module 待實作)")
+            .size(theme::FONT_SMALL).strong());
+    ui.add_space(theme::SP_XS);
+    ui.horizontal(|ui| {
+        ui.add_space(theme::SP_SM);
+        ui.colored_label(theme::TEXT_DIM,
+            RichText::new("(自動爬到、但 YAML 沒列的功能會出現在這裡)")
+                .size(theme::FONT_CAPTION).italics());
+    });
 }
 
 fn coverage_color(pct: f32) -> egui::Color32 {

--- a/src/ui_egui/coverage_panel.rs
+++ b/src/ui_egui/coverage_panel.rs
@@ -237,9 +237,10 @@ fn short_time(rfc3339: &str) -> &str {
 // ── 3-tier funnel (top of page) ──────────────────────────────────────────────
 
 fn show_funnel(ui: &mut egui::Ui, d: &CoverageData) {
-    let total = d.discovered.max(1);
+    let total = d.discovered.max(d.total_features).max(d.total_covered).max(d.scripted).max(1);
+    let dis_pct = d.discovered    as f32 / total as f32;
     let cov_pct = d.total_covered as f32 / total as f32;
-    let scr_pct = d.scripted as f32 / total as f32;
+    let scr_pct = d.scripted      as f32 / total as f32;
     let bar_w = 300.0;
 
     egui::Frame::new()
@@ -261,7 +262,7 @@ fn show_funnel(ui: &mut egui::Ui, d: &CoverageData) {
             ui.add_space(theme::SP_SM);
 
             funnel_row(ui, "探索 Discovered",
-                d.discovered, total, 1.0, theme::TEXT_DIM, bar_w);
+                d.discovered, total, dis_pct, theme::TEXT_DIM, bar_w);
             if matches!(d.discovery_status, DiscoveryStatus::NotRun) {
                 ui.horizontal(|ui| {
                     ui.add_space(160.0);

--- a/src/ui_egui/coverage_panel.rs
+++ b/src/ui_egui/coverage_panel.rs
@@ -14,22 +14,29 @@
 
 use std::sync::Arc;
 use eframe::egui::{self, RichText, ScrollArea};
-use crate::ui_service::{AppService, CoverageData, DiscoveryStatus};
+use crate::ui_service::{AppService, CoverageData, DiscoveryDataView, DiscoveryStatus};
 use super::theme;
 
 // ── State ────────────────────────────────────────────────────────────────────
 
 pub struct CoveragePanelState {
-    data:    Option<Result<CoverageData, String>>,
-    refresh: std::time::Instant,
+    data:           Option<Result<CoverageData, String>>,
+    discovery:      Option<Result<DiscoveryDataView, String>>,
+    refresh:        std::time::Instant,
+    discovery_seed: String,
+    /// Sticky launch toast — text + when shown — auto-clears after 6 s.
+    last_launch:    Option<(String, std::time::Instant)>,
 }
 
 impl Default for CoveragePanelState {
     fn default() -> Self {
         Self {
-            data:    None,
+            data:           None,
+            discovery:      None,
             // Force immediate load on first frame.
-            refresh: std::time::Instant::now() - std::time::Duration::from_secs(60),
+            refresh:        std::time::Instant::now() - std::time::Duration::from_secs(60),
+            discovery_seed: "https://redandan.github.io/?__test_role=buyer".to_string(),
+            last_launch:    None,
         }
     }
 }
@@ -37,11 +44,28 @@ impl Default for CoveragePanelState {
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 pub fn show(ui: &mut egui::Ui, svc: &Arc<dyn AppService>, state: &mut CoveragePanelState) {
+    // Refresh cadence: faster when crawling so progress updates live.
+    let crawling = matches!(
+        state.data.as_ref().and_then(|r| r.as_ref().ok()).map(|d| &d.discovery_status),
+        Some(DiscoveryStatus::Crawling { .. })
+    );
+    let refresh_secs = if crawling { 2 } else { 30 };
     if state.data.is_none()
-        || state.refresh.elapsed() > std::time::Duration::from_secs(30)
+        || state.refresh.elapsed() > std::time::Duration::from_secs(refresh_secs)
     {
-        state.data    = Some(svc.test_coverage_data());
-        state.refresh = std::time::Instant::now();
+        state.data      = Some(svc.test_coverage_data());
+        state.discovery = Some(svc.discovery_data());
+        state.refresh   = std::time::Instant::now();
+    }
+    if crawling {
+        ui.ctx().request_repaint_after(std::time::Duration::from_secs(2));
+    }
+
+    // Auto-clear sticky launch toast after 6 s.
+    if let Some((_, t)) = &state.last_launch {
+        if t.elapsed() > std::time::Duration::from_secs(6) {
+            state.last_launch = None;
+        }
     }
 
     // ── Header ───────────────────────────────────────────────────────────
@@ -54,13 +78,18 @@ pub fn show(ui: &mut egui::Ui, svc: &Arc<dyn AppService>, state: &mut CoveragePa
             if ui.add(egui::Button::new(
                 RichText::new("↻ Refresh").size(theme::FONT_CAPTION).color(theme::TEXT_DIM)
             ).frame(false)).clicked() {
-                state.data    = Some(svc.test_coverage_data());
-                state.refresh = std::time::Instant::now();
+                state.data      = Some(svc.test_coverage_data());
+                state.discovery = Some(svc.discovery_data());
+                state.refresh   = std::time::Instant::now();
             }
         });
     });
     ui.add_space(theme::SP_XS);
     theme::thin_separator(ui);
+    ui.add_space(theme::SP_SM);
+
+    // ── Discovery launcher row ───────────────────────────────────────────
+    show_discovery_launcher(ui, svc, state, crawling);
     ui.add_space(theme::SP_SM);
 
     ScrollArea::vertical().id_salt("coverage_panel").show(ui, |ui| {
@@ -80,10 +109,129 @@ pub fn show(ui: &mut egui::Ui, svc: &Arc<dyn AppService>, state: &mut CoveragePa
                 show_funnel(ui, data);
                 ui.add_space(theme::SP_LG);
                 show_groups(ui, data);
-                show_gaps(ui, data);
+                show_gaps(ui, data, state.discovery.as_ref());
             }
         }
     });
+}
+
+// ── Discovery launcher (URL input + Discover button + status) ───────────────
+
+fn show_discovery_launcher(
+    ui:       &mut egui::Ui,
+    svc:      &Arc<dyn AppService>,
+    state:    &mut CoveragePanelState,
+    crawling: bool,
+) {
+    egui::Frame::new()
+        .fill(theme::BG)
+        .corner_radius(4.0)
+        .inner_margin(egui::vec2(theme::SP_MD, theme::SP_XS))
+        .stroke(egui::Stroke::new(0.5, theme::BORDER))
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.colored_label(
+                    theme::TEXT_DIM,
+                    RichText::new("DISCOVERY")
+                        .size(theme::FONT_CAPTION).strong().monospace(),
+                );
+                ui.add_space(theme::SP_SM);
+
+                // Seed URL input
+                ui.add(
+                    egui::TextEdit::singleline(&mut state.discovery_seed)
+                        .desired_width(300.0)
+                        .font(egui::TextStyle::Monospace)
+                        .hint_text("seed URL…"),
+                );
+                ui.add_space(theme::SP_SM);
+
+                let btn_label = if crawling { "⌛ Crawling…" } else { "↻ Discover" };
+                let btn = egui::Button::new(
+                    RichText::new(btn_label)
+                        .size(theme::FONT_SMALL).strong()
+                        .color(if crawling { theme::TEXT_DIM } else { theme::BG }),
+                )
+                .fill(if crawling { theme::CARD } else { theme::ACCENT })
+                .corner_radius(4.0);
+                let enabled = !crawling && !state.discovery_seed.is_empty();
+                if ui.add_enabled(enabled, btn).clicked() {
+                    match svc.launch_discovery(&state.discovery_seed, 1) {
+                        Ok(rid) => {
+                            state.last_launch = Some((
+                                format!("✓ launched {rid}"),
+                                std::time::Instant::now(),
+                            ));
+                            // Force quick refresh so the funnel shows
+                            // Crawling state on the next frame.
+                            state.refresh = std::time::Instant::now()
+                                - std::time::Duration::from_secs(60);
+                        }
+                        Err(e) => {
+                            state.last_launch = Some((
+                                format!("✗ {e}"),
+                                std::time::Instant::now(),
+                            ));
+                        }
+                    }
+                }
+
+                // Status hint (right side)
+                ui.with_layout(
+                    egui::Layout::right_to_left(egui::Align::Center),
+                    |ui| {
+                        if let Some(Ok(d)) = state.discovery.as_ref() {
+                            match &d.status {
+                                DiscoveryStatus::NotRun => {
+                                    ui.colored_label(
+                                        theme::TEXT_DIM,
+                                        RichText::new("never run")
+                                            .size(theme::FONT_CAPTION).monospace(),
+                                    );
+                                }
+                                DiscoveryStatus::Crawling { started_at } => {
+                                    ui.colored_label(
+                                        theme::INFO,
+                                        RichText::new(format!("crawling since {}",
+                                            short_time(started_at)))
+                                            .size(theme::FONT_CAPTION).monospace(),
+                                    );
+                                }
+                                DiscoveryStatus::Done { at, total_widgets } => {
+                                    ui.colored_label(
+                                        theme::ACCENT,
+                                        RichText::new(format!("✓ {} widgets · {}",
+                                            total_widgets, short_time(at)))
+                                            .size(theme::FONT_CAPTION).monospace(),
+                                    );
+                                }
+                            }
+                        }
+                    },
+                );
+            });
+
+            // Sticky launch toast
+            if let Some((msg, _)) = &state.last_launch {
+                ui.add_space(theme::SP_XS);
+                let col = if msg.starts_with('✓') { theme::ACCENT } else { theme::DANGER };
+                ui.colored_label(col,
+                    RichText::new(msg).size(theme::FONT_CAPTION).monospace());
+            }
+        });
+}
+
+/// Render an RFC-3339 timestamp as just "HH:MM:SS" for compact UI strings.
+fn short_time(rfc3339: &str) -> &str {
+    // Extract the time portion between 'T' and '.' / 'Z' / '+'.
+    if let Some(t_idx) = rfc3339.find('T') {
+        let tail = &rfc3339[t_idx + 1..];
+        let end = tail.find(|c: char| c == '.' || c == 'Z' || c == '+' || c == '-')
+            .unwrap_or(tail.len());
+        &tail[..end]
+    } else {
+        rfc3339
+    }
 }
 
 // ── 3-tier funnel (top of page) ──────────────────────────────────────────────
@@ -256,7 +404,11 @@ fn show_groups(ui: &mut egui::Ui, d: &CoverageData) {
 
 // ── Bottom GAPS list ─────────────────────────────────────────────────────────
 
-fn show_gaps(ui: &mut egui::Ui, d: &CoverageData) {
+fn show_gaps(
+    ui:        &mut egui::Ui,
+    d:         &CoverageData,
+    discovery: Option<&Result<DiscoveryDataView, String>>,
+) {
     let mut coverage_gaps: Vec<(&str, &str, &str)> = Vec::new();
     for group in &d.groups {
         for feat in &group.features {
@@ -266,53 +418,257 @@ fn show_gaps(ui: &mut egui::Ui, d: &CoverageData) {
         }
     }
 
-    if coverage_gaps.is_empty() {
-        return;
-    }
-
-    ui.add_space(theme::SP_SM);
-    theme::thin_separator(ui);
-    ui.add_space(theme::SP_SM);
-
-    ui.colored_label(theme::DANGER,
-        RichText::new(format!("COVERAGE GAPS  {} missing", coverage_gaps.len()))
-            .size(theme::FONT_SMALL).strong());
-    ui.add_space(theme::SP_XS);
-    for (gname, fid, fname) in &coverage_gaps {
-        ui.horizontal(|ui| {
-            ui.add_space(theme::SP_SM);
-            ui.colored_label(theme::DANGER,
-                RichText::new("○").size(theme::FONT_CAPTION));
-            ui.colored_label(theme::TEXT_DIM,
-                RichText::new(*fname).size(theme::FONT_CAPTION));
-            ui.colored_label(theme::TEXT_DIM,
-                RichText::new(format!("— {gname}")).size(theme::FONT_CAPTION));
-            ui.with_layout(
-                egui::Layout::right_to_left(egui::Align::Center),
-                |ui| {
-                    ui.colored_label(theme::INFO,
-                        RichText::new(format!("agora_{fid}"))
-                            .size(theme::FONT_CAPTION).monospace())
-                        .on_hover_text("suggested YAML test name");
-                },
-            );
-        });
-    }
-
-    // Discovery gaps (mock — empty until real crawler ships).
-    ui.add_space(theme::SP_SM);
-    theme::thin_separator(ui);
-    ui.add_space(theme::SP_SM);
-    ui.colored_label(theme::TEXT_DIM,
-        RichText::new("DISCOVERY GAPS  0 (discovery module 待實作)")
-            .size(theme::FONT_SMALL).strong());
-    ui.add_space(theme::SP_XS);
-    ui.horizontal(|ui| {
+    if !coverage_gaps.is_empty() {
         ui.add_space(theme::SP_SM);
-        ui.colored_label(theme::TEXT_DIM,
-            RichText::new("(自動爬到、但 YAML 沒列的功能會出現在這裡)")
-                .size(theme::FONT_CAPTION).italics());
-    });
+        theme::thin_separator(ui);
+        ui.add_space(theme::SP_SM);
+
+        ui.colored_label(theme::DANGER,
+            RichText::new(format!("COVERAGE GAPS  {} missing", coverage_gaps.len()))
+                .size(theme::FONT_SMALL).strong());
+        ui.add_space(theme::SP_XS);
+        for (gname, fid, fname) in &coverage_gaps {
+            ui.horizontal(|ui| {
+                ui.add_space(theme::SP_SM);
+                ui.colored_label(theme::DANGER,
+                    RichText::new("○").size(theme::FONT_CAPTION));
+                ui.colored_label(theme::TEXT_DIM,
+                    RichText::new(*fname).size(theme::FONT_CAPTION));
+                ui.colored_label(theme::TEXT_DIM,
+                    RichText::new(format!("— {gname}")).size(theme::FONT_CAPTION));
+                ui.with_layout(
+                    egui::Layout::right_to_left(egui::Align::Center),
+                    |ui| {
+                        ui.colored_label(theme::INFO,
+                            RichText::new(format!("agora_{fid}"))
+                                .size(theme::FONT_CAPTION).monospace())
+                            .on_hover_text("suggested YAML test name");
+                    },
+                );
+            });
+        }
+    }
+
+    // Discovery gaps — features the crawler saw that don't match any
+    // tracked YAML feature label. Heuristic: case-insensitive label
+    // substring match in either direction; common UI chrome filtered out.
+    ui.add_space(theme::SP_SM);
+    theme::thin_separator(ui);
+    ui.add_space(theme::SP_SM);
+    match discovery {
+        Some(Ok(disc)) if disc.total > 0 => {
+            let gaps = discovery_gaps(&disc.features, d);
+            if gaps.is_empty() {
+                ui.colored_label(theme::ACCENT,
+                    RichText::new(format!(
+                        "DISCOVERY GAPS  0  (all {} discovered widgets match YAML)",
+                        disc.total
+                    )).size(theme::FONT_SMALL).strong());
+            } else {
+                ui.colored_label(theme::YELLOW,
+                    RichText::new(format!(
+                        "DISCOVERY GAPS  {} of {} (爬到但 YAML 沒列)",
+                        gaps.len(), disc.total,
+                    )).size(theme::FONT_SMALL).strong());
+                ui.add_space(theme::SP_XS);
+                for g in gaps.iter().take(50) {
+                    ui.horizontal(|ui| {
+                        ui.add_space(theme::SP_SM);
+                        ui.colored_label(theme::YELLOW,
+                            RichText::new("◆").size(theme::FONT_CAPTION));
+                        ui.colored_label(theme::TEXT,
+                            RichText::new(&g.label).size(theme::FONT_CAPTION));
+                        ui.colored_label(theme::TEXT_DIM,
+                            RichText::new(format!("[{}]", g.kind))
+                                .size(theme::FONT_CAPTION).monospace());
+                        ui.with_layout(
+                            egui::Layout::right_to_left(egui::Align::Center),
+                            |ui| {
+                                ui.colored_label(theme::TEXT_DIM,
+                                    RichText::new(&g.route)
+                                        .size(theme::FONT_CAPTION).monospace());
+                            },
+                        );
+                    });
+                }
+                if gaps.len() > 50 {
+                    ui.add_space(theme::SP_XS);
+                    ui.colored_label(theme::TEXT_DIM,
+                        RichText::new(format!("…and {} more (use MCP discovery_features for full list)",
+                            gaps.len() - 50)).size(theme::FONT_CAPTION).italics());
+                }
+            }
+        }
+        Some(Ok(_)) => {
+            ui.colored_label(theme::TEXT_DIM,
+                RichText::new("DISCOVERY GAPS  —")
+                    .size(theme::FONT_SMALL).strong());
+            ui.add_space(theme::SP_XS);
+            ui.horizontal(|ui| {
+                ui.add_space(theme::SP_SM);
+                ui.colored_label(theme::TEXT_DIM,
+                    RichText::new("(尚未跑過 discovery — 點上方 ↻ Discover 啟動)")
+                        .size(theme::FONT_CAPTION).italics());
+            });
+        }
+        Some(Err(e)) => {
+            ui.colored_label(theme::DANGER,
+                RichText::new(format!("DISCOVERY GAPS  ⚠ {e}"))
+                    .size(theme::FONT_SMALL).strong());
+        }
+        None => {
+            ui.colored_label(theme::TEXT_DIM,
+                RichText::new("DISCOVERY GAPS  Loading…")
+                    .size(theme::FONT_SMALL).strong());
+        }
+    }
+}
+
+// ── Discovery gaps diff ──────────────────────────────────────────────────────
+
+/// Diff discovered features against YAML coverage map. Returns features
+/// the crawler saw whose label doesn't appear (substring, case-insensitive)
+/// in any YAML feature name. Common UI chrome (Back / Close / Menu / OK …)
+/// is filtered out so the list focuses on app-specific widgets.
+fn discovery_gaps<'a>(
+    discovered: &'a [crate::ui_service::DiscoveredFeatureView],
+    coverage:   &CoverageData,
+) -> Vec<&'a crate::ui_service::DiscoveredFeatureView> {
+    use std::collections::HashSet;
+    let yaml_labels: HashSet<String> = coverage.groups.iter()
+        .flat_map(|g| g.features.iter())
+        .map(|f| f.name.to_lowercase())
+        .collect();
+    discovered.iter().filter(|d| {
+        let dl = d.label.to_lowercase();
+        if is_ui_chrome(&dl) { return false; }
+        !yaml_labels.iter().any(|y| {
+            // Two-way substring match — handles partial overlaps both ways.
+            y.contains(&dl) || (!dl.is_empty() && dl.len() > 1 && y.split_whitespace().any(|w| w == dl))
+                || dl.contains(y.as_str())
+        })
+    }).collect()
+}
+
+/// Common UI chrome labels not specific to product features.
+/// Filtered out of Discovery Gaps to reduce noise.
+fn is_ui_chrome(label: &str) -> bool {
+    matches!(label,
+        "back" | "close" | "menu" | "home" | "skip" | "ok" | "cancel"
+        | "next" | "previous" | "submit" | "save" | "delete" | "edit"
+        | "more" | "search" | "settings" | "login" | "logout" | "register"
+        | "返回" | "關閉" | "選單" | "首頁" | "跳過" | "確定" | "取消"
+        | "下一步" | "上一步" | "送出" | "儲存" | "刪除" | "編輯"
+        | "更多" | "搜尋" | "設定" | "登入" | "登出" | "註冊"
+    )
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui_service::{
+        CoverageData, CoverageFeatureView, CoverageGroupView,
+        DiscoveredFeatureView, DiscoveryStatus,
+    };
+
+    fn mk_coverage(features: &[(&str, &str, &str)]) -> CoverageData {
+        // features: list of (group, feature_name, status)
+        let mut groups_map: std::collections::HashMap<String, Vec<CoverageFeatureView>> =
+            std::collections::HashMap::new();
+        for (g, n, s) in features {
+            groups_map.entry(g.to_string()).or_default().push(CoverageFeatureView {
+                id: n.to_lowercase().replace(' ', "_"),
+                name: n.to_string(),
+                status: s.to_string(),
+                test_ids: vec![],
+            });
+        }
+        let groups: Vec<_> = groups_map.into_iter().map(|(name, feats)| {
+            CoverageGroupView {
+                id: name.to_lowercase(),
+                name,
+                role: String::new(),
+                covered: feats.iter().filter(|f| f.status != "missing").count(),
+                total: feats.len(),
+                features: feats,
+            }
+        }).collect();
+        let total_features = groups.iter().map(|g| g.total).sum();
+        let total_covered  = groups.iter().map(|g| g.covered).sum();
+        CoverageData {
+            product: "test".into(), version: "0".into(),
+            total_covered, total_features, groups,
+            discovered: total_features, scripted: 0,
+            discovery_status: DiscoveryStatus::NotRun,
+        }
+    }
+
+    fn mk_disc(label: &str) -> DiscoveredFeatureView {
+        DiscoveredFeatureView {
+            route: "/test".into(),
+            label: label.into(),
+            kind: "button".into(),
+            selector: None,
+            last_seen: "2026-05-02T00:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn gap_when_yaml_doesnt_have_label() {
+        let cov = mk_coverage(&[("Buyer", "Login", "confirmed")]);
+        let disc = vec![mk_disc("Place Order")];
+        let gaps = discovery_gaps(&disc, &cov);
+        assert_eq!(gaps.len(), 1);
+        assert_eq!(gaps[0].label, "Place Order");
+    }
+
+    #[test]
+    fn no_gap_when_yaml_contains_label() {
+        let cov = mk_coverage(&[("Buyer", "Place Order Flow", "confirmed")]);
+        let disc = vec![mk_disc("Place Order")];
+        let gaps = discovery_gaps(&disc, &cov);
+        assert!(gaps.is_empty(), "YAML 'Place Order Flow' should match discovered 'Place Order'");
+    }
+
+    #[test]
+    fn no_gap_when_label_contains_yaml() {
+        let cov = mk_coverage(&[("Buyer", "Login", "confirmed")]);
+        let disc = vec![mk_disc("Login Page")];
+        let gaps = discovery_gaps(&disc, &cov);
+        assert!(gaps.is_empty(), "discovered 'Login Page' should match YAML 'Login'");
+    }
+
+    #[test]
+    fn ui_chrome_filtered_out() {
+        let cov = mk_coverage(&[("Buyer", "Real Feature", "confirmed")]);
+        let disc = vec![
+            mk_disc("Back"),
+            mk_disc("Close"),
+            mk_disc("Settings"),
+            mk_disc("登出"),
+            mk_disc("返回"),
+        ];
+        let gaps = discovery_gaps(&disc, &cov);
+        assert!(gaps.is_empty(), "UI chrome should be filtered out, got {gaps:?}");
+    }
+
+    #[test]
+    fn case_insensitive() {
+        let cov = mk_coverage(&[("Buyer", "Place Order", "confirmed")]);
+        let disc = vec![mk_disc("PLACE ORDER")];
+        let gaps = discovery_gaps(&disc, &cov);
+        assert!(gaps.is_empty());
+    }
+
+    #[test]
+    fn empty_yaml_all_gaps() {
+        let cov = mk_coverage(&[]);
+        let disc = vec![mk_disc("Foo"), mk_disc("Bar")];
+        let gaps = discovery_gaps(&disc, &cov);
+        assert_eq!(gaps.len(), 2);
+    }
 }
 
 fn coverage_color(pct: f32) -> egui::Color32 {

--- a/src/ui_egui/dashboard.rs
+++ b/src/ui_egui/dashboard.rs
@@ -1,0 +1,429 @@
+//! Dashboard — main landing view (default after launch).
+//!
+//! Sections (top to bottom):
+//!   • ACTIVE      currently running tests (max 3)
+//!   • RECENT      last 8 completed runs
+//!   • COVERAGE    3-tier funnel card (Discovered / Covered / Scripted)
+//!   • BROWSER     status + URL + title
+//!
+//! Clicking any card / row signals a `DashboardAction` which the parent
+//! (mod.rs) translates into a view switch — usually `View::Testing` with the
+//! correct internal tab pre-selected.
+
+use std::sync::Arc;
+use eframe::egui::{self, RichText};
+use crate::ui_service::{AppService, CoverageData, DiscoveryStatus, TestRunView};
+use super::theme;
+
+#[derive(Default, PartialEq, Clone, Copy)]
+pub enum DashboardAction {
+    #[default]
+    None,
+    OpenTesting,
+    OpenTestingCoverage,
+    OpenTestingBrowser,
+}
+
+pub struct DashboardState {
+    coverage:         Option<Result<CoverageData, String>>,
+    coverage_refresh: std::time::Instant,
+}
+
+impl Default for DashboardState {
+    fn default() -> Self {
+        Self {
+            coverage:         None,
+            coverage_refresh: std::time::Instant::now() - std::time::Duration::from_secs(120),
+        }
+    }
+}
+
+pub fn show(
+    ui:    &mut egui::Ui,
+    svc:   &Arc<dyn AppService>,
+    state: &mut DashboardState,
+) -> DashboardAction {
+    let mut action = DashboardAction::None;
+
+    // Refresh coverage every 60 s (cheap — file read + YAML parse).
+    if state.coverage.is_none()
+        || state.coverage_refresh.elapsed() > std::time::Duration::from_secs(60)
+    {
+        state.coverage         = Some(svc.test_coverage_data());
+        state.coverage_refresh = std::time::Instant::now();
+    }
+
+    // ── Header row ───────────────────────────────────────────────────────
+    ui.horizontal(|ui| {
+        ui.label(
+            RichText::new("DASHBOARD")
+                .size(theme::FONT_TITLE).strong().color(theme::TEXT),
+        );
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            let btn = egui::Button::new(
+                RichText::new("▶ Run Test")
+                    .size(theme::FONT_SMALL).color(theme::BG).strong(),
+            )
+            .fill(theme::ACCENT)
+            .corner_radius(4.0);
+            if ui.add(btn).clicked() {
+                action = DashboardAction::OpenTesting;
+            }
+        });
+    });
+    ui.add_space(theme::SP_SM);
+    theme::thin_separator(ui);
+    ui.add_space(theme::SP_LG);
+
+    egui::ScrollArea::vertical().id_salt("dashboard_scroll").show(ui, |ui| {
+        // ── ACTIVE ───────────────────────────────────────────────────────
+        let active = svc.active_test_runs();
+        section_header(ui, &format!("ACTIVE  ({})", active.len()));
+        if active.is_empty() {
+            empty_card(ui, "目前沒有正在執行的測試");
+        } else {
+            for run in active.iter().take(3) {
+                if active_run_card(ui, run).clicked() {
+                    action = DashboardAction::OpenTesting;
+                }
+            }
+        }
+        ui.add_space(theme::SP_LG);
+
+        // ── RECENT ───────────────────────────────────────────────────────
+        let recent = svc.recent_test_runs(8);
+        section_header(ui, &format!("RECENT  ({} of last 8)", recent.len()));
+        if recent.is_empty() {
+            empty_card(ui, "尚無歷史紀錄");
+        } else {
+            for run in &recent {
+                if recent_run_row(ui, run).clicked() {
+                    action = DashboardAction::OpenTesting;
+                }
+            }
+        }
+        ui.add_space(theme::SP_LG);
+
+        // ── COVERAGE 3-tier funnel ───────────────────────────────────────
+        section_header(ui, "COVERAGE");
+        if coverage_card(ui, state.coverage.as_ref()).clicked() {
+            action = DashboardAction::OpenTestingCoverage;
+        }
+        ui.add_space(theme::SP_LG);
+
+        // ── BROWSER ──────────────────────────────────────────────────────
+        section_header(ui, "BROWSER");
+        if browser_card(ui, svc).clicked() {
+            action = DashboardAction::OpenTestingBrowser;
+        }
+    });
+
+    action
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn section_header(ui: &mut egui::Ui, text: &str) {
+    ui.colored_label(
+        theme::TEXT_DIM,
+        RichText::new(text)
+            .size(theme::FONT_SMALL).strong().monospace(),
+    );
+    ui.add_space(theme::SP_XS);
+}
+
+fn empty_card(ui: &mut egui::Ui, msg: &str) {
+    egui::Frame::new()
+        .fill(theme::CARD)
+        .corner_radius(4.0)
+        .inner_margin(theme::SP_MD)
+        .show(ui, |ui| {
+            ui.colored_label(
+                theme::TEXT_DIM,
+                RichText::new(msg).size(theme::FONT_CAPTION),
+            );
+        });
+}
+
+fn active_run_card(ui: &mut egui::Ui, run: &TestRunView) -> egui::Response {
+    let inner = egui::Frame::new()
+        .fill(theme::CARD)
+        .corner_radius(4.0)
+        .inner_margin(theme::SP_MD)
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.colored_label(
+                    theme::INFO,
+                    RichText::new("▶").size(theme::FONT_BODY).strong(),
+                );
+                ui.colored_label(
+                    theme::TEXT,
+                    RichText::new(&run.test_id)
+                        .size(theme::FONT_BODY).monospace().strong(),
+                );
+                if let Some(step) = run.step {
+                    ui.colored_label(
+                        theme::TEXT_DIM,
+                        RichText::new(format!("· step {step}"))
+                            .size(theme::FONT_CAPTION).monospace(),
+                    );
+                }
+            });
+            if let Some(an) = &run.analysis {
+                let trunc = truncate(an, 110);
+                ui.add_space(2.0);
+                ui.colored_label(
+                    theme::TEXT_DIM,
+                    RichText::new(trunc).size(theme::FONT_CAPTION),
+                );
+            }
+        });
+    ui.add_space(theme::SP_XS);
+    inner.response
+        .interact(egui::Sense::click())
+        .on_hover_cursor(egui::CursorIcon::PointingHand)
+}
+
+fn recent_run_row(ui: &mut egui::Ui, run: &TestRunView) -> egui::Response {
+    let (col, sym) = match run.status.as_str() {
+        "passed"  => (theme::ACCENT,   "✓"),
+        "failed"  => (theme::DANGER,   "✗"),
+        "timeout" => (theme::YELLOW,   "⌚"),
+        "error"   => (theme::DANGER,   "!"),
+        _         => (theme::TEXT_DIM, "·"),
+    };
+    let inner = egui::Frame::new()
+        .fill(theme::CARD)
+        .corner_radius(3.0)
+        .inner_margin(egui::vec2(theme::SP_MD, theme::SP_XS))
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.colored_label(
+                    col,
+                    RichText::new(sym).size(theme::FONT_BODY).strong(),
+                );
+                ui.colored_label(
+                    col,
+                    RichText::new(run.status.to_uppercase())
+                        .size(theme::FONT_CAPTION).monospace().strong(),
+                );
+                ui.add_space(theme::SP_SM);
+                ui.colored_label(
+                    theme::TEXT,
+                    RichText::new(&run.test_id)
+                        .size(theme::FONT_SMALL).monospace(),
+                );
+                ui.with_layout(
+                    egui::Layout::right_to_left(egui::Align::Center),
+                    |ui| {
+                        if let Some(d) = run.duration_ms {
+                            ui.colored_label(
+                                theme::TEXT_DIM,
+                                RichText::new(format!("{:.1}s", d as f32 / 1000.0))
+                                    .size(theme::FONT_CAPTION).monospace(),
+                            );
+                        }
+                        if let Some(rate) = run.pass_rate {
+                            if rate < 0.7 {
+                                ui.colored_label(
+                                    theme::YELLOW,
+                                    RichText::new(format!("· flaky {:.0}%", rate * 100.0))
+                                        .size(theme::FONT_CAPTION).monospace(),
+                                );
+                            }
+                        }
+                    },
+                );
+            });
+        });
+    ui.add_space(2.0);
+    inner.response
+        .interact(egui::Sense::click())
+        .on_hover_cursor(egui::CursorIcon::PointingHand)
+}
+
+fn coverage_card(
+    ui:   &mut egui::Ui,
+    data: Option<&Result<CoverageData, String>>,
+) -> egui::Response {
+    let inner = egui::Frame::new()
+        .fill(theme::CARD)
+        .corner_radius(4.0)
+        .inner_margin(theme::SP_MD)
+        .show(ui, |ui| {
+            match data {
+                None => {
+                    ui.colored_label(theme::TEXT_DIM, "Loading…");
+                }
+                Some(Err(e)) => {
+                    ui.colored_label(
+                        theme::DANGER,
+                        RichText::new(format!("⚠ {e}"))
+                            .size(theme::FONT_SMALL),
+                    );
+                }
+                Some(Ok(d)) => render_coverage_funnel(ui, d),
+            }
+        });
+    inner.response
+        .interact(egui::Sense::click())
+        .on_hover_cursor(egui::CursorIcon::PointingHand)
+}
+
+fn render_coverage_funnel(ui: &mut egui::Ui, d: &CoverageData) {
+    let total = d.discovered.max(1);
+    let cov_pct = d.total_covered as f32 / total as f32;
+    let scr_pct = d.scripted as f32 / total as f32;
+    let bar_w = 220.0;
+
+    // Header row: product · version · open hint
+    ui.horizontal(|ui| {
+        ui.colored_label(
+            theme::TEXT,
+            RichText::new(&d.product).size(theme::FONT_BODY).strong(),
+        );
+        ui.colored_label(
+            theme::TEXT_DIM,
+            RichText::new(format!("v{}", d.version))
+                .size(theme::FONT_CAPTION).monospace(),
+        );
+        ui.with_layout(
+            egui::Layout::right_to_left(egui::Align::Center),
+            |ui| {
+                ui.colored_label(
+                    theme::INFO,
+                    RichText::new("Open full →").size(theme::FONT_CAPTION),
+                );
+            },
+        );
+    });
+    ui.add_space(theme::SP_SM);
+
+    funnel_row(ui, "探索 Discovered", d.discovered, total, 1.0,     theme::TEXT_DIM, bar_w);
+    if matches!(d.discovery_status, DiscoveryStatus::NotRun) {
+        ui.horizontal(|ui| {
+            ui.add_space(140.0);
+            ui.colored_label(
+                theme::TEXT_DIM,
+                RichText::new("(mock — discovery 模組待實作)")
+                    .size(theme::FONT_CAPTION).italics(),
+            );
+        });
+    }
+    funnel_row(ui, "覆蓋 Covered",   d.total_covered, total, cov_pct, theme::ACCENT,   bar_w);
+    funnel_row(ui, "有腳本 Scripted", d.scripted,      total, scr_pct, theme::INFO,     bar_w);
+}
+
+fn funnel_row(
+    ui:    &mut egui::Ui,
+    label: &str,
+    n:     usize,
+    _max:  usize,
+    pct:   f32,
+    color: egui::Color32,
+    bar_w: f32,
+) {
+    ui.horizontal(|ui| {
+        ui.allocate_ui_with_layout(
+            egui::vec2(140.0, 18.0),
+            egui::Layout::left_to_right(egui::Align::Center),
+            |ui| {
+                ui.colored_label(
+                    theme::TEXT,
+                    RichText::new(label).size(theme::FONT_SMALL),
+                );
+            },
+        );
+        ui.allocate_ui_with_layout(
+            egui::vec2(40.0, 18.0),
+            egui::Layout::right_to_left(egui::Align::Center),
+            |ui| {
+                ui.colored_label(
+                    theme::TEXT,
+                    RichText::new(format!("{n}"))
+                        .size(theme::FONT_SMALL).monospace().strong(),
+                );
+            },
+        );
+        ui.add_space(theme::SP_SM);
+        let (rect, _) = ui.allocate_exact_size(
+            egui::vec2(bar_w, 8.0),
+            egui::Sense::hover(),
+        );
+        let p = ui.painter_at(rect);
+        p.rect_filled(rect, 2.0, theme::BORDER);
+        let fw = (rect.width() * pct.clamp(0.0, 1.0)).max(0.0);
+        p.rect_filled(
+            egui::Rect::from_min_size(rect.min, egui::vec2(fw, 8.0)),
+            2.0,
+            color,
+        );
+        ui.add_space(theme::SP_SM);
+        ui.colored_label(
+            theme::TEXT_DIM,
+            RichText::new(format!("{:.0}%", pct * 100.0))
+                .size(theme::FONT_CAPTION).monospace(),
+        );
+    });
+    ui.add_space(theme::SP_XS);
+}
+
+fn browser_card(ui: &mut egui::Ui, svc: &Arc<dyn AppService>) -> egui::Response {
+    let inner = egui::Frame::new()
+        .fill(theme::CARD)
+        .corner_radius(4.0)
+        .inner_margin(theme::SP_MD)
+        .show(ui, |ui| {
+            let open  = svc.browser_is_open();
+            let url   = svc.browser_url();
+            let title = svc.browser_title();
+            ui.horizontal(|ui| {
+                let (col, txt) = if open {
+                    (theme::ACCENT, "● LIVE")
+                } else {
+                    (theme::TEXT_DIM, "○ OFF")
+                };
+                ui.colored_label(
+                    col,
+                    RichText::new(txt)
+                        .size(theme::FONT_SMALL).monospace().strong(),
+                );
+                ui.add_space(theme::SP_SM);
+                if let Some(t) = &title {
+                    ui.colored_label(
+                        theme::TEXT,
+                        RichText::new(t).size(theme::FONT_SMALL),
+                    );
+                }
+                ui.with_layout(
+                    egui::Layout::right_to_left(egui::Align::Center),
+                    |ui| {
+                        ui.colored_label(
+                            theme::INFO,
+                            RichText::new("Open monitor →").size(theme::FONT_CAPTION),
+                        );
+                    },
+                );
+            });
+            if let Some(u) = &url {
+                ui.add_space(2.0);
+                ui.colored_label(
+                    theme::TEXT_DIM,
+                    RichText::new(u)
+                        .size(theme::FONT_CAPTION).monospace(),
+                );
+            }
+        });
+    inner.response
+        .interact(egui::Sense::click())
+        .on_hover_cursor(egui::CursorIcon::PointingHand)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let head: String = s.chars().take(max).collect();
+        format!("{head}…")
+    }
+}

--- a/src/ui_egui/dashboard.rs
+++ b/src/ui_egui/dashboard.rs
@@ -271,9 +271,13 @@ fn coverage_card(
 }
 
 fn render_coverage_funnel(ui: &mut egui::Ui, d: &CoverageData) {
-    let total = d.discovered.max(1);
-    let cov_pct = d.total_covered as f32 / total as f32;
-    let scr_pct = d.scripted as f32 / total as f32;
+    // Funnel denominator must accommodate the largest tier — discovered may
+    // legitimately be smaller than covered (e.g., crawler only walked one
+    // route but YAML covers all roles). Otherwise percentages exceed 100 %.
+    let total = d.discovered.max(d.total_features).max(d.total_covered).max(d.scripted).max(1);
+    let dis_pct = d.discovered     as f32 / total as f32;
+    let cov_pct = d.total_covered  as f32 / total as f32;
+    let scr_pct = d.scripted       as f32 / total as f32;
     let bar_w = 220.0;
 
     // Header row: product · version · open hint
@@ -299,7 +303,7 @@ fn render_coverage_funnel(ui: &mut egui::Ui, d: &CoverageData) {
     });
     ui.add_space(theme::SP_SM);
 
-    funnel_row(ui, "探索 Discovered", d.discovered, total, 1.0,     theme::TEXT_DIM, bar_w);
+    funnel_row(ui, "探索 Discovered", d.discovered, total, dis_pct, theme::TEXT_DIM, bar_w);
     if matches!(d.discovery_status, DiscoveryStatus::NotRun) {
         ui.horizontal(|ui| {
             ui.add_space(140.0);

--- a/src/ui_egui/mod.rs
+++ b/src/ui_egui/mod.rs
@@ -17,6 +17,9 @@ mod ops_panel;
 mod testing_panel;
 mod automation_panel;
 mod system_panel;
+mod top_bar;
+mod dashboard;
+mod command_palette;
 
 use std::sync::Arc;
 use std::collections::VecDeque;
@@ -29,11 +32,20 @@ use crate::ui_service::*;
 
 #[derive(PartialEq, Clone)]
 enum View {
-    Workspace(usize),
-    Testing,      // Runs | Coverage | Browser  (tab bar inside)
-    Automation,   // Dev Squad | MCP            (tab bar inside)
-    Ops,          // AI Router | Tasks | Cost   (tab bar inside)
-    System,       // Settings | Log             (tab bar inside)
+    Dashboard,             // Default landing — summary + Coverage card + Browser preview
+    Testing,               // Runs | Coverage | Browser (legacy sub-tabs; commit 5 split)
+    Workspace(usize),      // Per-agent detail
+}
+
+/// Modal overlay opened from the palette / gear menu. Renders the existing
+/// panel inside an `egui::Window` over the central panel.
+#[derive(PartialEq, Clone, Copy, Default)]
+enum Modal {
+    #[default]
+    None,
+    Automation,   // Dev Squad + MCP (automation_panel::show)
+    Ops,          // AI Router | Tasks | Cost (ops_panel::show)
+    System,       // Settings | Logs (system_panel::show)
 }
 
 // ── Toast ────────────────────────────────────────────────────────────────────
@@ -65,11 +77,22 @@ pub struct SirinApp {
 
     sidebar_state:    sidebar::SidebarState,
     workspace_state:  workspace::WorkspaceState,
-    // Consolidated panels (v0.4.7)
+    dashboard_state:  dashboard::DashboardState,
     testing_state:    testing_panel::TestingPanelState,
+    // Wired via command palette / gear menu (Modal overlay).
     automation_state: automation_panel::AutomationPanelState,
     ops_state:        ops_panel::OpsPanelState,
     system_state:     system_panel::SystemPanelState,
+    palette_state:    command_palette::PaletteState,
+    modal:            Modal,
+    gear_menu_open:   bool,
+
+    /// Has the first-run config_check been performed this session?
+    /// On `false`, we run `config_check()` once and force-open the System
+    /// modal (Settings tab) if any Error-severity issue is reported —
+    /// covers the "missing LLM API key" case so first-time users aren't
+    /// stuck with a broken dashboard.
+    first_run_check_done: bool,
 
     /// Dismissed once per session so the banner doesn't reappear after dismiss
     update_banner_dismissed: bool,
@@ -86,7 +109,7 @@ impl SirinApp {
         theme::apply(&cc.egui_ctx);
         let agents = svc.list_agents();
         Self {
-            svc, view: View::Workspace(0), agents,
+            svc, view: View::Dashboard, agents,
             tasks: Vec::new(),
             pending_counts: std::collections::HashMap::new(),
             last_refresh: std::time::Instant::now() - std::time::Duration::from_secs(60),
@@ -94,12 +117,17 @@ impl SirinApp {
             renaming: None,
             sidebar_state:    Default::default(),
             workspace_state:  Default::default(),
+            dashboard_state:  Default::default(),
             testing_state:    Default::default(),
             automation_state: Default::default(),
             ops_state:        Default::default(),
             system_state:     Default::default(),
+            palette_state:    Default::default(),
+            modal:            Modal::None,
+            gear_menu_open:   false,
+            first_run_check_done: false,
             update_banner_dismissed: false,
-            prev_view: View::Workspace(0),
+            prev_view: View::Dashboard,
             // Far in the past so initial frame doesn't show a spurious loading.
             view_changed_at: std::time::Instant::now() - std::time::Duration::from_secs(60),
         }
@@ -112,12 +140,200 @@ impl SirinApp {
         for a in &self.agents { self.pending_counts.insert(a.id.clone(), self.svc.pending_count(&a.id)); }
         self.last_refresh = std::time::Instant::now();
     }
+
+    /// Map a palette selection to a view switch / modal open.
+    fn handle_palette_choice(&mut self, entry: command_palette::PaletteEntry) {
+        use command_palette::PaletteEntry as E;
+        match entry {
+            E::Coverage => {
+                self.view = View::Testing;
+                self.testing_state.tab = testing_panel::TestingTab::Coverage;
+            }
+            E::Browser => {
+                self.view = View::Testing;
+                self.testing_state.tab = testing_panel::TestingTab::Browser;
+            }
+            E::DevSquad => {
+                self.modal = Modal::Automation;
+                self.automation_state.tab = automation_panel::AutoTab::Squad;
+            }
+            E::McpPlayground => {
+                self.modal = Modal::Automation;
+                self.automation_state.tab = automation_panel::AutoTab::Mcp;
+            }
+            E::AiRouter => {
+                self.modal = Modal::Ops;
+                self.ops_state.tab = ops_panel::OpsTab::AiRouter;
+            }
+            E::SessionTasks => {
+                self.modal = Modal::Ops;
+                self.ops_state.tab = ops_panel::OpsTab::SessionTasks;
+            }
+            E::CostKb => {
+                self.modal = Modal::Ops;
+                self.ops_state.tab = ops_panel::OpsTab::CostKb;
+            }
+            E::Settings => {
+                self.modal = Modal::System;
+                self.system_state.tab = system_panel::SysTab::Settings;
+            }
+            E::Logs => {
+                self.modal = Modal::System;
+                self.system_state.tab = system_panel::SysTab::Log;
+            }
+            E::GoDashboard => {
+                self.view = View::Dashboard;
+                self.modal = Modal::None;
+            }
+        }
+    }
+
+    /// Render the active modal as a centered Window over the central panel.
+    fn show_modal(&mut self, ctx: &egui::Context) {
+        let title = match self.modal {
+            Modal::Automation => "Automation",
+            Modal::Ops        => "OPS",
+            Modal::System     => "System",
+            Modal::None       => return,
+        };
+
+        let mut close_requested = false;
+        let screen = ctx.screen_rect();
+        let win_size = egui::vec2(
+            (screen.width()  * 0.78).clamp(640.0, 1100.0),
+            (screen.height() * 0.78).clamp(420.0,  820.0),
+        );
+
+        egui::Window::new(title)
+            .collapsible(false)
+            .resizable(true)
+            .default_size(win_size)
+            .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
+            .frame(
+                egui::Frame::new()
+                    .fill(theme::BG)
+                    .inner_margin(theme::SP_MD)
+                    .stroke(egui::Stroke::new(1.0, theme::BORDER))
+                    .corner_radius(4.0),
+            )
+            .show(ctx, |ui| {
+                // Header with close button
+                ui.horizontal(|ui| {
+                    ui.colored_label(theme::TEXT_DIM,
+                        RichText::new(title).size(theme::FONT_SMALL).strong().monospace());
+                    ui.with_layout(
+                        egui::Layout::right_to_left(egui::Align::Center),
+                        |ui| {
+                            if ui.add(egui::Button::new(
+                                RichText::new("✕ Close").size(theme::FONT_CAPTION)
+                                    .color(theme::TEXT_DIM),
+                            ).frame(false)).clicked() {
+                                close_requested = true;
+                            }
+                        },
+                    );
+                });
+                ui.add_space(theme::SP_XS);
+                theme::thin_separator(ui);
+                ui.add_space(theme::SP_SM);
+
+                match self.modal {
+                    Modal::Automation => automation_panel::show(ui, &self.svc, &mut self.automation_state),
+                    Modal::Ops        => ops_panel::show(ui, &self.svc, &mut self.ops_state),
+                    Modal::System     => system_panel::show(ui, &self.svc, &self.agents, &mut self.system_state),
+                    Modal::None       => {}
+                }
+            });
+
+        // Esc closes too.
+        if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
+            close_requested = true;
+        }
+        if close_requested {
+            self.modal = Modal::None;
+        }
+    }
+
+    /// Gear dropdown — small menu anchored top-right with quick links.
+    fn show_gear_menu(&mut self, ctx: &egui::Context) {
+        let mut close = false;
+        egui::Area::new(egui::Id::new("gear_menu"))
+            .anchor(egui::Align2::RIGHT_TOP, egui::vec2(-12.0, 36.0))
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::popup(ui.style())
+                    .fill(theme::CARD)
+                    .corner_radius(4.0)
+                    .inner_margin(theme::SP_SM)
+                    .stroke(egui::Stroke::new(1.0, theme::BORDER))
+                    .show(ui, |ui| {
+                        ui.set_min_width(180.0);
+                        if menu_item(ui, "Settings").clicked() {
+                            self.modal = Modal::System;
+                            self.system_state.tab = system_panel::SysTab::Settings;
+                            close = true;
+                        }
+                        if menu_item(ui, "System Logs").clicked() {
+                            self.modal = Modal::System;
+                            self.system_state.tab = system_panel::SysTab::Log;
+                            close = true;
+                        }
+                        if menu_item(ui, "Open Command Palette  ⌘K").clicked() {
+                            self.palette_state.open();
+                            close = true;
+                        }
+                        ui.add_space(theme::SP_XS);
+                        theme::thin_separator(ui);
+                        ui.colored_label(theme::TEXT_DIM,
+                            RichText::new(concat!("Sirin v", env!("CARGO_PKG_VERSION")))
+                                .size(theme::FONT_CAPTION).monospace());
+                    });
+            });
+        // Click outside closes the menu.
+        if ctx.input(|i| i.pointer.any_click())
+            && !ctx.is_pointer_over_area()
+        {
+            close = true;
+        }
+        if close { self.gear_menu_open = false; }
+    }
+}
+
+fn menu_item(ui: &mut egui::Ui, label: &str) -> egui::Response {
+    let (rect, resp) = ui.allocate_exact_size(
+        egui::vec2(ui.available_width(), 24.0),
+        egui::Sense::click(),
+    );
+    if resp.hovered() {
+        ui.painter().rect_filled(rect, 3.0, theme::HOVER);
+    }
+    ui.painter().text(
+        egui::pos2(rect.left() + theme::SP_SM, rect.center().y),
+        egui::Align2::LEFT_CENTER, label,
+        egui::FontId::proportional(theme::FONT_SMALL), theme::TEXT,
+    );
+    resp.on_hover_cursor(egui::CursorIcon::PointingHand)
 }
 
 impl eframe::App for SirinApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         if self.last_refresh.elapsed() > std::time::Duration::from_secs(5) { self.refresh(); }
         ctx.request_repaint_after(std::time::Duration::from_secs(5));
+
+        // ── First-run config check: force Settings modal on missing LLM key ─
+        if !self.first_run_check_done {
+            self.first_run_check_done = true;
+            let issues = self.svc.config_check();
+            let has_error = issues.iter().any(|i| i.severity == ConfigSeverity::Error);
+            if has_error {
+                self.modal = Modal::System;
+                self.system_state.tab = system_panel::SysTab::Settings;
+                self.toasts.push_back(Toast::from_event(ToastEvent {
+                    level: ToastLevel::Error,
+                    text: "設定有錯誤 — 請先在 Settings 修正".into(),
+                }));
+            }
+        }
 
         // Deactivate screenshot pump when Testing panel is not on Browser tab
         if !matches!(self.view, View::Testing) {
@@ -129,6 +345,26 @@ impl eframe::App for SirinApp {
         for te in self.svc.poll_toasts() { self.toasts.push_back(Toast::from_event(te)); }
         let now = std::time::Instant::now();
         self.toasts.retain(|t| t.expires > now);
+
+        // ── Global Ctrl/Cmd+K shortcut ──────────────────────────────────
+        // Listen on the *first* update of each frame so the palette opens
+        // even when focus is in another widget. We avoid consuming events
+        // because TextEdit may also need them — we just observe.
+        let palette_shortcut = ctx.input(|i| {
+            (i.modifiers.ctrl || i.modifiers.command || i.modifiers.mac_cmd)
+                && i.key_pressed(egui::Key::K)
+        });
+        if palette_shortcut && !self.palette_state.open {
+            self.palette_state.open();
+        }
+
+        // ── Top status bar (32pt, always visible above sidebar/central) ──
+        let top_action = top_bar::show(ctx, &self.svc);
+        match top_action {
+            top_bar::TopBarAction::OpenPalette => self.palette_state.open(),
+            top_bar::TopBarAction::OpenGearMenu => self.gear_menu_open = !self.gear_menu_open,
+            top_bar::TopBarAction::None => {}
+        }
 
         sidebar::show(ctx, &self.svc, &self.agents, &self.pending_counts, &mut self.view, &mut self.renaming, &mut self.sidebar_state);
 
@@ -157,14 +393,44 @@ impl eframe::App for SirinApp {
                     show_loading(ui);
                 } else {
                     match self.view.clone() {
+                        View::Dashboard => {
+                            let act = dashboard::show(ui, &self.svc, &mut self.dashboard_state);
+                            match act {
+                                dashboard::DashboardAction::OpenTesting => {
+                                    self.view = View::Testing;
+                                }
+                                dashboard::DashboardAction::OpenTestingCoverage => {
+                                    self.view = View::Testing;
+                                    self.testing_state.tab = testing_panel::TestingTab::Coverage;
+                                }
+                                dashboard::DashboardAction::OpenTestingBrowser => {
+                                    self.view = View::Testing;
+                                    self.testing_state.tab = testing_panel::TestingTab::Browser;
+                                }
+                                dashboard::DashboardAction::None => {}
+                            }
+                        }
+                        View::Testing        => testing_panel::show(ui, &self.svc, &mut self.testing_state),
                         View::Workspace(idx) => workspace::show(ui, &self.svc, &self.agents, idx, &self.tasks, &self.pending_counts, &mut self.workspace_state),
-                        View::Testing    => testing_panel::show(ui, &self.svc, &mut self.testing_state),
-                        View::Automation => automation_panel::show(ui, &self.svc, &mut self.automation_state),
-                        View::Ops        => ops_panel::show(ui, &self.svc, &mut self.ops_state),
-                        View::System     => system_panel::show(ui, &self.svc, &self.agents, &mut self.system_state),
                     }
                 }
             });
+
+        // ── Modal overlay (shown above central panel, below palette) ─────
+        if self.modal != Modal::None {
+            self.show_modal(ctx);
+        }
+
+        // ── Gear menu (anchored under the gear icon in the top bar) ──────
+        if self.gear_menu_open {
+            self.show_gear_menu(ctx);
+        }
+
+        // ── Command palette (top-most overlay) ───────────────────────────
+        if let Some(entry) = command_palette::show(ctx, &mut self.palette_state) {
+            self.handle_palette_choice(entry);
+            self.palette_state.close();
+        }
 
         // Toast overlay
         if !self.toasts.is_empty() {

--- a/src/ui_egui/sidebar.rs
+++ b/src/ui_egui/sidebar.rs
@@ -242,35 +242,10 @@ fn show_icon_nav(
         }
     });
 
-    ui.add_space(theme::SP_XS);
-    thin_strip(ui);
-    ui.add_space(theme::SP_XS);
-
-    // ── 4 functional groups ───────────────────────────────────────────────
-    nav_icon(ui, Icon::Lines,  "Testing\n(Runs|Coverage|Browser)", View::Testing,    view);
-    nav_icon(ui, Icon::People, "Automation\n(Squad|MCP)",          View::Automation, view);
-    nav_icon(ui, Icon::Globe,  "OPS\n(AI|Tasks|Cost/KB)",          View::Ops,        view);
-    nav_icon(ui, Icon::Gear,   "System\n(Settings|Log)",           View::System,     view);
-
-    // ── Bottom: expand button + status dots ──────────────────────────
+    // ── Bottom: Dashboard button + Testing button + expand arrow ─────
+    // (System status now lives in the top bar — no dots here.)
     ui.with_layout(egui::Layout::bottom_up(egui::Align::Center), |ui| {
         ui.add_space(theme::SP_SM);
-
-        let s = svc.system_status();
-        // RPC dot
-        let (r, resp) = ui.allocate_exact_size(egui::vec2(ui.available_width(), 14.0), egui::Sense::hover());
-        ui.painter().circle_filled(r.center(), 3.5, if s.rpc_running { theme::ACCENT } else { theme::DANGER });
-        resp.on_hover_text(if s.rpc_running { "RPC: running" } else { "RPC: stopped" });
-        ui.add_space(5.0);
-
-        // Telegram dot
-        let (r, resp) = ui.allocate_exact_size(egui::vec2(ui.available_width(), 14.0), egui::Sense::hover());
-        ui.painter().circle_filled(r.center(), 3.5, if s.telegram_connected { theme::ACCENT } else { theme::DANGER });
-        resp.on_hover_text(if s.telegram_connected { "Telegram: connected" } else { "Telegram: offline" });
-
-        ui.add_space(theme::SP_SM);
-        thin_strip(ui);
-        ui.add_space(theme::SP_XS);
 
         // Expand button (›)
         let cw = ui.available_width();
@@ -281,7 +256,18 @@ fn show_icon_nav(
             egui::FontId::proportional(18.0), col);
         if resp.clicked() { state.expanded = true; }
         resp.on_hover_text("Expand sidebar");
+
+        ui.add_space(theme::SP_XS);
+        thin_strip(ui);
+        ui.add_space(theme::SP_SM);
+
+        // Testing entry (one-click into the testing panel)
+        nav_icon(ui, Icon::Lines, "Testing", View::Testing, view);
+        // Dashboard entry
+        nav_icon(ui, Icon::Monitor, "Dashboard", View::Dashboard, view);
     });
+    // Suppress unused-arg warning when the bottom helpers don't need svc.
+    let _ = svc;
 }
 
 /// Sirin "S" badge — accent-colored rounded square at the very top.
@@ -480,45 +466,21 @@ fn show_expanded(
     ui.add_space(theme::SP_SM);
     theme::thin_separator(ui);
 
-    // ── 4 unified sections ────────────────────────────────────────────────
-    nav_item(ui, "Testing",    View::Testing,    view);
-    nav_item(ui, "Automation", View::Automation, view);
-    nav_item(ui, "OPS",        View::Ops,        view);
-    nav_item(ui, "System",     View::System,     view);
+    // ── 2 nav items (was 4 buckets) ──────────────────────────────────────
+    nav_item(ui, "Dashboard", View::Dashboard, view);
+    nav_item(ui, "Testing",   View::Testing,   view);
 
     ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
         ui.add_space(theme::SP_SM);
-        let status = svc.system_status();
-        ui.horizontal(|ui| {
-            ui.add_space(theme::SP_MD);
-            status_indicator(ui, "TG", status.telegram_connected);
-            ui.add_space(theme::SP_MD);
-            status_indicator(ui, "RPC", status.rpc_running);
-        });
+        ui.colored_label(
+            theme::TEXT_DIM,
+            eframe::egui::RichText::new("v0.4.7  ⌘K = palette")
+                .size(theme::FONT_CAPTION).monospace(),
+        );
         ui.add_space(theme::SP_XS);
         theme::thin_separator(ui);
     });
-}
-
-fn group_header(ui: &mut egui::Ui, text: &str, open: bool) -> bool {
-    let caret = if open { "▼" } else { "▶" };
-    let mut clicked = false;
-    ui.horizontal(|ui| {
-        ui.add_space(theme::SP_MD);
-        let resp = ui.add(
-            egui::Label::new(
-                RichText::new(format!("{caret}  {text}"))
-                    .size(theme::FONT_CAPTION)
-                    .strong()
-                    .color(theme::TEXT_DIM),
-            )
-            .selectable(false)
-            .sense(egui::Sense::click()),
-        );
-        clicked = resp.clicked();
-    });
-    ui.add_space(theme::SP_XS);
-    clicked
+    let _ = svc;
 }
 
 fn group_header_inline(ui: &mut egui::Ui, text: &str, open: &mut bool) {
@@ -557,10 +519,4 @@ fn nav_item(ui: &mut egui::Ui, label: &str, target: View, current: &mut View) {
         egui::FontId::proportional(theme::FONT_BODY), text_color);
 
     if response.clicked() { *current = target; }
-}
-
-fn status_indicator(ui: &mut egui::Ui, label: &str, ok: bool) {
-    let color = if ok { theme::ACCENT } else { theme::DANGER };
-    ui.colored_label(color, RichText::new("●").size(theme::FONT_CAPTION));
-    ui.colored_label(theme::TEXT_DIM, RichText::new(label).size(theme::FONT_CAPTION));
 }

--- a/src/ui_egui/top_bar.rs
+++ b/src/ui_egui/top_bar.rs
@@ -1,0 +1,157 @@
+//! Top status bar — 32pt header always visible above sidebar + central panel.
+//!
+//! Layout (left to right):
+//!   [Sirin v0.4.7]  ●Browser  ●RPC  ●TG   ✓ PASS test_id   ───   url…  ⚙  ⌘K
+//!
+//! Browser/RPC/TG dots: green = running, red = stopped. Hover for tooltip.
+//! Last verdict: pulled from recent_test_runs(1).
+//! Browser URL: truncated to last 50 chars when long.
+//! Gear → opens gear menu (commit 4 wires Settings/Logs/About).
+//! ⌘K hint → palette opens via global shortcut (commit 3).
+
+use std::sync::Arc;
+use eframe::egui::{self, RichText};
+use crate::ui_service::AppService;
+use super::theme;
+
+#[derive(Default, PartialEq, Clone, Copy)]
+pub enum TopBarAction {
+    #[default]
+    None,
+    OpenGearMenu,
+    OpenPalette,
+}
+
+/// Render the 32pt top status bar. Returns the action triggered this frame.
+pub fn show(ctx: &egui::Context, svc: &Arc<dyn AppService>) -> TopBarAction {
+    let mut action = TopBarAction::None;
+
+    egui::TopBottomPanel::top("sirin_top_bar")
+        .exact_height(32.0)
+        .frame(
+            egui::Frame::new()
+                .fill(theme::BG)
+                .inner_margin(egui::vec2(theme::SP_MD, 4.0))
+                .stroke(egui::Stroke::new(0.5, theme::BORDER)),
+        )
+        .show(ctx, |ui| {
+            ui.horizontal_centered(|ui| {
+                // ── Left cluster ──────────────────────────────────────
+                ui.label(
+                    RichText::new(concat!("Sirin v", env!("CARGO_PKG_VERSION")))
+                        .size(theme::FONT_SMALL).strong().color(theme::TEXT),
+                );
+                ui.add_space(theme::SP_LG);
+
+                let s = svc.system_status();
+                draw_dot(ui, "Browser", svc.browser_is_open());
+                draw_dot(ui, "RPC", s.rpc_running);
+                draw_dot(ui, "TG", s.telegram_connected);
+
+                ui.add_space(theme::SP_MD);
+
+                // Last test verdict (newest run)
+                let recent = svc.recent_test_runs(1);
+                if let Some(last) = recent.first() {
+                    let (col, txt) = match last.status.as_str() {
+                        "passed"   => (theme::ACCENT, "✓ PASS"),
+                        "failed"   => (theme::DANGER, "✗ FAIL"),
+                        "timeout"  => (theme::YELLOW, "⌚ TIMEOUT"),
+                        "error"    => (theme::DANGER, "✗ ERROR"),
+                        "running"  => (theme::INFO,   "▶ RUNNING"),
+                        "queued"   => (theme::TEXT_DIM, "⋯ QUEUED"),
+                        other      => (theme::TEXT_DIM, other),
+                    };
+                    ui.colored_label(col,
+                        RichText::new(txt).size(theme::FONT_CAPTION).strong());
+                    ui.add_space(theme::SP_XS);
+                    ui.colored_label(theme::TEXT_DIM,
+                        RichText::new(&last.test_id)
+                            .size(theme::FONT_CAPTION).monospace());
+                }
+
+                // ── Right cluster (right-to-left layout) ──────────────
+                ui.with_layout(
+                    egui::Layout::right_to_left(egui::Align::Center),
+                    |ui| {
+                        // ⌘K hint — visual cue, also clickable as fallback
+                        let resp = ui.add(
+                            egui::Button::new(
+                                RichText::new("⌘K")
+                                    .size(theme::FONT_CAPTION)
+                                    .monospace()
+                                    .color(theme::TEXT_DIM),
+                            )
+                            .frame(false),
+                        );
+                        if resp.clicked() { action = TopBarAction::OpenPalette; }
+                        resp.on_hover_text("Command palette (Ctrl+K / Cmd+K)");
+
+                        ui.add_space(theme::SP_SM);
+
+                        // Gear button
+                        let resp = ui.add(
+                            egui::Button::new(
+                                RichText::new("⚙")
+                                    .size(15.0)
+                                    .color(theme::TEXT_DIM),
+                            )
+                            .frame(false),
+                        );
+                        if resp.clicked() { action = TopBarAction::OpenGearMenu; }
+                        resp.on_hover_text("Settings · Logs · About");
+
+                        ui.add_space(theme::SP_MD);
+
+                        // Browser URL (truncated tail)
+                        if let Some(url) = svc.browser_url() {
+                            let trunc = truncate_url(&url, 60);
+                            let url_for_hover = url.clone();
+                            ui.add(egui::Label::new(
+                                RichText::new(trunc)
+                                    .size(theme::FONT_CAPTION)
+                                    .monospace()
+                                    .color(theme::TEXT_DIM),
+                            ).truncate())
+                            .on_hover_text(url_for_hover);
+                        }
+                    },
+                );
+            });
+        });
+
+    action
+}
+
+/// Single status dot + label. ~70px wide cell so layout stays predictable.
+fn draw_dot(ui: &mut egui::Ui, label: &str, ok: bool) {
+    let color = if ok { theme::ACCENT } else { theme::DANGER };
+    let (rect, resp) = ui.allocate_exact_size(
+        egui::vec2(54.0, 16.0),
+        egui::Sense::hover(),
+    );
+    let dot_pos = egui::pos2(rect.left() + 4.0, rect.center().y);
+    ui.painter().circle_filled(dot_pos, 3.5, color);
+    ui.painter().text(
+        egui::pos2(rect.left() + 12.0, rect.center().y),
+        egui::Align2::LEFT_CENTER,
+        label,
+        egui::FontId::proportional(theme::FONT_CAPTION),
+        theme::TEXT_DIM,
+    );
+    resp.on_hover_text(format!(
+        "{label}: {}",
+        if ok { "running" } else { "stopped" }
+    ));
+}
+
+/// Keep the tail of a URL within `max` chars (e.g. "…domain.com/path/x").
+fn truncate_url(url: &str, max: usize) -> String {
+    if url.chars().count() <= max {
+        url.to_string()
+    } else {
+        let tail: String = url.chars().rev().take(max - 1).collect::<Vec<_>>()
+            .into_iter().rev().collect();
+        format!("…{tail}")
+    }
+}

--- a/src/ui_service.rs
+++ b/src/ui_service.rs
@@ -508,6 +508,29 @@ pub struct CoverageData {
     pub discovery_status: DiscoveryStatus,
 }
 
+/// One feature Sirin's auto-crawler observed in the running app.
+/// The diff between this set and the YAML coverage map drives the
+/// "Discovery Gaps" list in the Coverage panel.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiscoveredFeatureView {
+    pub route:     String,
+    pub label:     String,
+    /// "button" | "link" | "form_input" | "page" | "tab" | "menuitem"
+    pub kind:      String,
+    pub selector:  Option<String>,
+    pub last_seen: String,
+}
+
+/// Top-level discovery snapshot — Issue #247.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiscoveryDataView {
+    pub status:        DiscoveryStatus,
+    pub total:         u32,
+    pub features:      Vec<DiscoveredFeatureView>,
+    /// RFC-3339 timestamp of the last completed run, if any.
+    pub last_run_at:   Option<String>,
+}
+
 /// Test runner data for the Test Dashboard panel — recent history + active runs.
 pub trait TestRunnerService: Send + Sync + 'static {
     /// Most-recent completed runs from SQLite (newest first).
@@ -524,6 +547,12 @@ pub trait TestRunnerService: Send + Sync + 'static {
     /// Parse `config/coverage/agora_market.yaml` and return a typed coverage
     /// snapshot.  Cheap (file read + parse, no DB queries).
     fn test_coverage_data(&self) -> Result<CoverageData, String>;
+    /// Snapshot of the auto-discovery state — Issue #247.
+    /// Returns NotRun + empty features when the crawler has never run.
+    fn discovery_data(&self) -> Result<DiscoveryDataView, String>;
+    /// Kick off a discovery crawl asynchronously. Returns the run_id.
+    /// `max_depth` caps recursion (clickable elements within clickables).
+    fn launch_discovery(&self, seed_url: &str, max_depth: u32) -> Result<String, String>;
 }
 
 /// Aggregate trait the UI consumes as `Arc<dyn AppService>`.

--- a/src/ui_service.rs
+++ b/src/ui_service.rs
@@ -471,7 +471,28 @@ pub struct CoverageGroupView {
     pub features: Vec<CoverageFeatureView>,
 }
 
+/// Status of the auto-discovery crawler (separate process that scans the
+/// running app for widgets/routes and writes them to a SQLite inventory).
+/// Commit 2 ships with `NotRun` — the real crawler lands in a follow-up PR.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DiscoveryStatus {
+    /// Discovery has never been run — UI shows "未實作 (mock)" label.
+    NotRun,
+    /// Crawler is currently running.
+    #[allow(dead_code)]
+    Crawling { started_at: String },
+    /// Last finished run timestamp (RFC-3339) and total widgets found.
+    #[allow(dead_code)]
+    Done { at: String, total_widgets: u32 },
+}
+
 /// Top-level coverage snapshot for the whole product.
+///
+/// 3-tier funnel:
+///   1. **discovered** — features Sirin's auto-crawler found (≥ total_features)
+///   2. **covered**    — alias of `total_covered`; features with at least one test_id
+///   3. **scripted**   — covered features whose tests have graduated from LLM
+///                       decision-making to deterministic replay scripts
 #[derive(Debug, Clone, PartialEq)]
 pub struct CoverageData {
     pub product:        String,
@@ -479,6 +500,12 @@ pub struct CoverageData {
     pub total_covered:  usize,
     pub total_features: usize,
     pub groups:         Vec<CoverageGroupView>,
+    /// Auto-discovery total — for the scaffold, equals total_features (mock).
+    pub discovered:     usize,
+    /// Covered features whose tests are deterministic scripts (no-LLM replay).
+    /// Heuristic in commit 2: counts features with status == "confirmed".
+    pub scripted:       usize,
+    pub discovery_status: DiscoveryStatus,
 }
 
 /// Test runner data for the Test Dashboard panel — recent history + active runs.

--- a/src/ui_service_impl/mod.rs
+++ b/src/ui_service_impl/mod.rs
@@ -362,17 +362,100 @@ impl TestRunnerService for RealService {
             });
         }
 
-        // Discovery layer: until the auto-crawler ships, mock as
-        // discovered == total_features (every feature in YAML is "known").
-        let discovered = total_features;
+        // Discovery layer (Issue #247) — read from SQLite when the crawler
+        // has run; fall back to total_features (mock) until then.
+        let (discovered, discovery_status) =
+            match crate::test_runner::discovery::latest_run() {
+                Ok(Some(run)) => {
+                    let count = crate::test_runner::discovery::feature_count()
+                        .unwrap_or(total_features as u32);
+                    let status = match run.status.as_str() {
+                        "running" => crate::ui_service::DiscoveryStatus::Crawling {
+                            started_at: run.started_at,
+                        },
+                        "done" => crate::ui_service::DiscoveryStatus::Done {
+                            at: run.finished_at.unwrap_or(run.started_at),
+                            total_widgets: run.total_widgets.unwrap_or(0),
+                        },
+                        _ => crate::ui_service::DiscoveryStatus::NotRun,
+                    };
+                    (count as usize, status)
+                }
+                _ => (total_features, crate::ui_service::DiscoveryStatus::NotRun),
+            };
 
         Ok(CoverageData {
             product, version,
             total_covered, total_features, groups,
             discovered,
             scripted: total_scripted,
-            discovery_status: crate::ui_service::DiscoveryStatus::NotRun,
+            discovery_status,
         })
+    }
+
+    fn discovery_data(&self) -> Result<DiscoveryDataView, String> {
+        use crate::ui_service::{DiscoveryStatus, DiscoveredFeatureView};
+
+        let latest = crate::test_runner::discovery::latest_run()?;
+        let features_raw = crate::test_runner::discovery::list_features()?;
+        let features: Vec<DiscoveredFeatureView> = features_raw.into_iter().map(|f| {
+            DiscoveredFeatureView {
+                route: f.route,
+                label: f.label,
+                kind: f.kind,
+                selector: f.selector,
+                last_seen: f.last_seen,
+            }
+        }).collect();
+        let total = features.len() as u32;
+
+        let (status, last_run_at) = match latest {
+            None => (DiscoveryStatus::NotRun, None),
+            Some(r) => {
+                let st = match r.status.as_str() {
+                    "running" => DiscoveryStatus::Crawling { started_at: r.started_at.clone() },
+                    "done"    => DiscoveryStatus::Done {
+                        at: r.finished_at.clone().unwrap_or(r.started_at.clone()),
+                        total_widgets: r.total_widgets.unwrap_or(0),
+                    },
+                    _ => DiscoveryStatus::NotRun,
+                };
+                (st, r.finished_at.or(Some(r.started_at)))
+            }
+        };
+
+        Ok(DiscoveryDataView { status, total, features, last_run_at })
+    }
+
+    fn launch_discovery(&self, seed_url: &str, max_depth: u32) -> Result<String, String> {
+        let run_id = format!(
+            "disc_{}",
+            chrono::Utc::now().format("%Y%m%d_%H%M%S")
+        );
+        crate::test_runner::discovery::begin_run(&run_id, seed_url, max_depth)?;
+
+        // Detached thread — UI polls latest_run() to track progress.  Errors
+        // get persisted as run.status = "failed" + error message.
+        let run_id_owned = run_id.clone();
+        let seed_owned   = seed_url.to_string();
+        std::thread::spawn(move || {
+            match crate::test_runner::discovery::crawl_app(
+                &seed_owned, max_depth, &run_id_owned,
+            ) {
+                Ok(count) => {
+                    let _ = crate::test_runner::discovery::finish_run(
+                        &run_id_owned, "done", Some(count), None,
+                    );
+                }
+                Err(e) => {
+                    let _ = crate::test_runner::discovery::finish_run(
+                        &run_id_owned, "failed", Some(0), Some(&e),
+                    );
+                }
+            }
+        });
+
+        Ok(run_id)
     }
 }
 

--- a/src/ui_service_impl/mod.rs
+++ b/src/ui_service_impl/mod.rs
@@ -311,6 +311,7 @@ impl TestRunnerService for RealService {
 
         let mut total_covered  = 0usize;
         let mut total_features = 0usize;
+        let mut total_scripted = 0usize;
         let mut groups = Vec::new();
 
         for g in groups_raw {
@@ -339,6 +340,13 @@ impl TestRunnerService for RealService {
 
                 if status != "missing" && !test_ids.is_empty() {
                     covered_count += 1;
+                    // Scaffold heuristic: "confirmed" = stable enough that the
+                    // test can be promoted to a deterministic replay script.
+                    // Real implementation will check per-test replay_mode in
+                    // the run history (see plan §Coverage 3-Tier Model).
+                    if status == "confirmed" {
+                        total_scripted += 1;
+                    }
                 }
                 features.push(CoverageFeatureView { id: fid, name: fname, status, test_ids });
             }
@@ -354,7 +362,17 @@ impl TestRunnerService for RealService {
             });
         }
 
-        Ok(CoverageData { product, version, total_covered, total_features, groups })
+        // Discovery layer: until the auto-crawler ships, mock as
+        // discovered == total_features (every feature in YAML is "known").
+        let discovered = total_features;
+
+        Ok(CoverageData {
+            product, version,
+            total_covered, total_features, groups,
+            discovered,
+            scripted: total_scripted,
+            discovery_status: crate::ui_service::DiscoveryStatus::NotRun,
+        })
     }
 }
 


### PR DESCRIPTION
Closes part of #253 (Option C — token-handling hardening; Options A/B keystore/scope still backlog).

## Summary

- Adds `scripts/fetch-handoff.sh.example` — reference copy of the user-level SessionStart hook script (`~/.claude/scripts/fetch-handoff.sh`) so anyone forking Sirin can install the handoff workflow with the security fix already in place.
- The actual `~/.claude/scripts/fetch-handoff.sh` on the maintainer's machine has also been updated in place (not committed — it is personal config under `~/.claude`).

## What changed in the script (vs. previous version)

Previously the agora-trading KB fallback path read bearer tokens into shell vars and passed them on `curl`'s argv:

```bash
TRADING_TOKEN=$(read_tok agora-trading)
OPS_TOKEN=$(read_tok agora-ops)
curl -H "Authorization: $TRADING_TOKEN" -H "X-OPS-Authorization: $OPS_TOKEN" ...
```

`ps aux` / `/proc/<pid>/cmdline` could see the tokens for the duration of the curl call.

New approach:
- `umask 077` at script start
- A python helper reads `~/.claude.json` and writes the two `header = "..."` lines **directly into a 600-mode tempfile** — tokens never traverse shell vars, env vars, or stdout pipes.
- `curl -K <tempfile>` consumes the headers from the file. `argv` only contains the path to the tempfile.
- `trap cleanup EXIT INT TERM` shreds (where available) and removes the tempfile.

## Verification

Run while pgrep'ing curl and dumping `/proc/<pid>/cmdline`:

```
=== fetched OK? ===
=== KB handoff: sirin-handoff-latest ===
=== curl cmdlines captured ===
=== contains token? ===
PASS: no token in cmdline
```

Both paths still work end-to-end (Sirin MCP fast path + KB fallback). Fail-safe behaviour preserved (silent `exit 0` on any error).

## What this PR does *not* do

- Does **not** modify `~/.claude.json` or any user-level config in this repo.
- Does **not** implement Option A (OS keystore — Windows Credential Manager / macOS Keychain). That's a larger cross-OS effort and stays as #253 follow-up.
- Does **not** implement Option B (low-scope read-only OPS token). Server-side change, separate work.

## Test plan

- [x] Run `~/.claude/scripts/fetch-handoff.sh sirin` → handoff content emitted to stdout
- [x] Force fallback path (point Sirin URL at a closed port) → KB fallback succeeds
- [x] Watch `/proc/<curl_pid>/cmdline` while fetch runs → no `Bearer …` / `eyJ…` / `sk-…` strings
- [x] Tempfile path: created with `mktemp`, chmod 600, removed on EXIT trap
- [x] Fail-safe: missing `~/.claude.json` keys → silent `exit 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)